### PR TITLE
auto refresh token on client call

### DIFF
--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -66,8 +66,12 @@ class FolioClient
     )
   end
 
+  # Public methods available on the FolioClient below
+  # Wrap methods in `TokenWrapper` to ensure a new token is fetched automatically if expired
   def fetch_hrid(...)
-    inventory = Inventory.new(self)
-    inventory.fetch_hrid(...)
+    TokenWrapper.refresh(config, connection) do
+      inventory = Inventory.new(self)
+      inventory.fetch_hrid(...)
+    end
   end
 end

--- a/lib/folio_client/token_wrapper.rb
+++ b/lib/folio_client/token_wrapper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "byebug"
+class FolioClient
+  # Wraps API operations to request new access token if expired
+  class TokenWrapper
+    def self.refresh(config, connection, &block)
+      yield
+    rescue UnexpectedResponse::UnauthorizedError
+      config.token = Authenticator.token(config.login_params, connection)
+      yield
+    end
+  end
+end

--- a/lib/folio_client/token_wrapper.rb
+++ b/lib/folio_client/token_wrapper.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
-require "byebug"
 class FolioClient
   # Wraps API operations to request new access token if expired
   class TokenWrapper
-    def self.refresh(config, connection, &block)
+    def self.refresh(config, connection)
       yield
     rescue UnexpectedResponse::UnauthorizedError
       config.token = Authenticator.token(config.login_params, connection)

--- a/lib/folio_client/unexpected_response.rb
+++ b/lib/folio_client/unexpected_response.rb
@@ -18,6 +18,8 @@ class FolioClient
     # @param [Faraday::Response] response
     def self.call(response)
       case response.status
+      when 401
+        raise UnauthorizedError, "There was a problem with the access token: #{response.body}"
       when 403
         raise ForbiddenError, "The operation requires privileges which the client does not have: #{response.body}"
       when 404

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -101,9 +101,10 @@ RSpec.describe FolioClient do
     end
 
     it "fetches new token and retries" do
-      expect(client.config.token).to eq expired_token
-      expect(client.fetch_hrid(barcode: "1234")).to eq hrid
-      expect(client.config.token).to eq new_token
+      expect { client.fetch_hrid(barcode: "1234") }
+        .to change(client.config, :token)
+        .from(expired_token)
+        .to(new_token)
     end
   end
 end

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -82,4 +82,28 @@ RSpec.describe FolioClient do
       expect(client.instance).to have_received(:fetch_hrid).with(barcode:)
     end
   end
+
+  # Tests the TokenWrapper that requests a new token, with a method that might first encounter the error
+  context "when token is expired" do
+    let(:inventory) { instance_double(FolioClient::Inventory, fetch_hrid: nil) }
+    let(:hrid) { "in56789" }
+    let(:expired_token) { "expired_token" }
+    let(:new_token) { "new_token" }
+
+    before do
+      allow(FolioClient::Inventory).to receive(:new).and_return(inventory)
+      allow(FolioClient::Authenticator).to receive(:token).and_return(expired_token, new_token)
+      response_values = [:raise, hrid]
+      allow(inventory).to receive(:fetch_hrid).twice do
+        v = response_values.shift
+        (v == :raise) ? raise(FolioClient::UnexpectedResponse::UnauthorizedError) : v
+      end
+    end
+
+    it "fetches new token and retries" do
+      expect(client.config.token).to eq expired_token
+      expect(client.fetch_hrid(barcode: "1234")).to eq hrid
+      expect(client.config.token).to eq new_token
+    end
+  end
 end


### PR DESCRIPTION
Fixes #9 - request a new token automatically if expired with a wrapper class, same concept as in the globus-client

Tested on the console and with a new spec.

Note: i borrowed the spec from the globus-client, but it's not really testing what's happening there correctly, since the mocking that's done here is not actually mocking a raise followed by a return.  Separate PR for adjusting the test in globus client so it's actually testing it correctly.