### PR TITLE
Move custom errors into top-level module namespace

### DIFF
--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -13,6 +13,24 @@ Zeitwerk::Loader.for_gem.setup
 class FolioClient
   include Singleton
 
+  # Base class for all FolioClient errors
+  class Error < StandardError; end
+
+  # Error raised by the Folio Auth API returns a 422 Unauthorized
+  class UnauthorizedError < Error; end
+
+  # Error raised when the Folio API returns a 404 NotFound, or returns 0 results when one was expected
+  class ResourceNotFound < Error; end
+
+  # Error raised when e.g. exactly one result was expected, but more than one was returned
+  class MultipleResourcesFound < Error; end
+
+  # Error raised when the Folio API returns a 403 Forbidden
+  class ForbiddenError < Error; end
+
+  # Error raised when the Folio API returns a 500
+  class ServiceUnavailable < Error; end
+
   DEFAULT_HEADERS = {
     accept: "application/json, text/plain",
     content_type: "application/json"

--- a/lib/folio_client/inventory.rb
+++ b/lib/folio_client/inventory.rb
@@ -26,11 +26,11 @@ class FolioClient
 
     # @param hrid [String] folio instance HRID
     # @param status_id [String] uuid for an instance status code
-    # @raise [FolioClient::UnexpectedResponse::ResourceNotFound] if search by hrid returns 0 results
+    # @raise [ResourceNotFound] if search by hrid returns 0 results
     def has_instance_status?(hrid:, status_id:)
       # get the instance record and its statusId
       instance = client.get("/inventory/instances", {query: "hrid==#{hrid}"})
-      raise FolioClient::UnexpectedResponse::ResourceNotFound, "No matching instance found for #{hrid}" if instance["totalRecords"] == 0
+      raise ResourceNotFound, "No matching instance found for #{hrid}" if instance["totalRecords"] == 0
 
       instance_status_id = instance.dig("instances", 0, "statusId")
 

--- a/lib/folio_client/source_storage.rb
+++ b/lib/folio_client/source_storage.rb
@@ -17,8 +17,8 @@ class FolioClient
       response_hash = client.get("/source-storage/source-records", {instanceHrid: instance_hrid})
 
       record_count = response_hash["totalRecords"]
-      raise FolioClient::UnexpectedResponse::ResourceNotFound, "No records found for #{instance_hrid}" if record_count.zero?
-      raise FolioClient::UnexpectedResponse::MultipleResourcesFound, "Expected 1 record for #{instance_hrid}, but found #{record_count}" if record_count > 1
+      raise ResourceNotFound, "No records found for #{instance_hrid}" if record_count.zero?
+      raise MultipleResourcesFound, "Expected 1 record for #{instance_hrid}, but found #{record_count}" if record_count > 1
 
       response_hash["sourceRecords"].first["parsedRecord"]["content"]
     end

--- a/lib/folio_client/token_wrapper.rb
+++ b/lib/folio_client/token_wrapper.rb
@@ -5,7 +5,7 @@ class FolioClient
   class TokenWrapper
     def self.refresh(config, connection)
       yield
-    rescue UnexpectedResponse::UnauthorizedError
+    rescue UnauthorizedError
       config.token = Authenticator.token(config.login_params, connection)
       yield
     end

--- a/lib/folio_client/unexpected_response.rb
+++ b/lib/folio_client/unexpected_response.rb
@@ -3,24 +3,6 @@
 class FolioClient
   # Handles unexpected responses when communicating with Folio
   class UnexpectedResponse
-    # Base class for all FolioClient errors
-    class FolioClientError < StandardError; end
-
-    # Error raised by the Folio Auth API returns a 422 Unauthorized
-    class UnauthorizedError < FolioClientError; end
-
-    # Error raised when the Folio API returns a 404 NotFound, or returns 0 results when one was expected
-    class ResourceNotFound < FolioClientError; end
-
-    # Error raised when e.g. exactly one result was expected, but more than one was returned
-    class MultipleResourcesFound < FolioClientError; end
-
-    # Error raised when the Folio API returns a 403 Forbidden
-    class ForbiddenError < FolioClientError; end
-
-    # Error raised when the Folio API returns a 500
-    class ServiceUnavailable < FolioClientError; end
-
     # @param [Faraday::Response] response
     def self.call(response)
       case response.status

--- a/spec/folio_client/authenticator_spec.rb
+++ b/spec/folio_client/authenticator_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe FolioClient::Authenticator do
       subject(:authenticator) { described_class.new(login_params, connection) }
 
       it "raises the correct exception" do
-        expect { authenticator.token }.to raise_error(FolioClient::UnexpectedResponse::UnauthorizedError)
+        expect { authenticator.token }.to raise_error(FolioClient::UnauthorizedError)
       end
     end
   end

--- a/spec/folio_client/inventory_spec.rb
+++ b/spec/folio_client/inventory_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe FolioClient::Inventory do
       }
 
       it "raises an error" do
-        expect { inventory.has_instance_status?(hrid:, status_id:) }.to raise_error(FolioClient::UnexpectedResponse::ResourceNotFound, "No matching instance found for #{hrid}")
+        expect { inventory.has_instance_status?(hrid:, status_id:) }.to raise_error(FolioClient::ResourceNotFound, "No matching instance found for #{hrid}")
       end
     end
   end

--- a/spec/folio_client/source_storage_spec.rb
+++ b/spec/folio_client/source_storage_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe FolioClient::SourceStorage do
     }
 
     it "raises a NotFound exception" do
-      expect { source_storage.fetch_marc_hash(instance_hrid:) }.to raise_error(FolioClient::UnexpectedResponse::ResourceNotFound, "No records found for #{instance_hrid}")
+      expect { source_storage.fetch_marc_hash(instance_hrid:) }.to raise_error(FolioClient::ResourceNotFound, "No records found for #{instance_hrid}")
     end
   end
 
@@ -200,7 +200,7 @@ RSpec.describe FolioClient::SourceStorage do
     }
 
     it "raises a MultipleRecordsForIdentifier exception" do
-      expect { source_storage.fetch_marc_hash(instance_hrid:) }.to raise_error(FolioClient::UnexpectedResponse::MultipleResourcesFound, "Expected 1 record for #{instance_hrid}, but found 2")
+      expect { source_storage.fetch_marc_hash(instance_hrid:) }.to raise_error(FolioClient::MultipleResourcesFound, "Expected 1 record for #{instance_hrid}, but found 2")
     end
   end
 end

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe FolioClient do
       response_values = [:raise, hrid]
       allow(inventory).to receive(:fetch_hrid).twice do
         v = response_values.shift
-        (v == :raise) ? raise(FolioClient::UnexpectedResponse::UnauthorizedError) : v
+        (v == :raise) ? raise(FolioClient::UnauthorizedError) : v
       end
     end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Constants are part of the interface, and exceptions are referenced outside the `UnexpectedResponse` context, so I figure it makes more sense for these to be defined where they may be referenced without knowledge of implemention details (namely, the `UnexpectedResponse` class).

Also, rename the redundant `FolioClient::FolioClientError` to `FolioClient::Error`.

**NOTE**: This will be a breaking change for any consumer that directly references these error classes.

# How was this change tested? 🤨

CI
