### PR TITLE
target ruby version 3.0 for rubocop and update syntax

### DIFF
--- a/.rubocop/custom.yml
+++ b/.rubocop/custom.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.0
   DisplayCopNames: true
   SuggestExtensions: false
   Exclude:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # FolioClient
 
-FolioClient is a Ruby gem that acts as a client to the RESTful HTTP APIs provided by the Folio ILS API.
+FolioClient is a Ruby gem that acts as a client to the RESTful HTTP APIs provided by the Folio ILS API.  It requires ruby 3.0 or better.
 
 ## Installation
 

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -41,7 +41,7 @@ class FolioClient
     # @param login_params [Hash] the folio client login params (username:, password:)
     # @param okapi_headers [Hash] the okapi specific headers to add (X-Okapi-Tenant:, User-Agent:)
     def configure(url:, login_params:, okapi_headers:)
-      instance.config = OpenStruct.new(url:, login_params:, okapi_headers:, token: nil)
+      instance.config = OpenStruct.new(url: url, login_params: login_params, okapi_headers: okapi_headers, token: nil)
 
       instance.config.token = Authenticator.token(login_params, connection)
 

--- a/spec/folio_client/authenticator_spec.rb
+++ b/spec/folio_client/authenticator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe FolioClient::Authenticator do
-  let(:args) { {url:, login_params:, okapi_headers:} }
+  let(:args) { {url: url, login_params: login_params, okapi_headers: okapi_headers} }
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }

--- a/spec/folio_client/inventory_spec.rb
+++ b/spec/folio_client/inventory_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FolioClient::Inventory do
     described_class.new(client)
   end
 
-  let(:args) { {url:, login_params:, okapi_headers:} }
+  let(:args) { {url: url, login_params: login_params, okapi_headers: okapi_headers} }
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }
@@ -57,7 +57,7 @@ RSpec.describe FolioClient::Inventory do
       }
 
       it "returns the instance hrid" do
-        expect(inventory.fetch_hrid(barcode:)).to eq(hrid)
+        expect(inventory.fetch_hrid(barcode: barcode)).to eq(hrid)
       end
     end
 
@@ -69,7 +69,7 @@ RSpec.describe FolioClient::Inventory do
       let(:inventory_instance_response) {}
 
       it "returns nil" do
-        expect(inventory.fetch_hrid(barcode:)).to be_nil
+        expect(inventory.fetch_hrid(barcode: barcode)).to be_nil
       end
     end
 
@@ -87,7 +87,7 @@ RSpec.describe FolioClient::Inventory do
       let(:inventory_instance_response) { {} }
 
       it "returns nil" do
-        expect(inventory.fetch_hrid(barcode:)).to be_nil
+        expect(inventory.fetch_hrid(barcode: barcode)).to be_nil
       end
     end
   end
@@ -122,7 +122,7 @@ RSpec.describe FolioClient::Inventory do
       }
 
       it "returns true" do
-        expect(inventory.has_instance_status?(hrid:, status_id:)).to be true
+        expect(inventory.has_instance_status?(hrid: hrid, status_id: status_id)).to be true
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe FolioClient::Inventory do
       }
 
       it "returns false" do
-        expect(inventory.has_instance_status?(hrid:, status_id:)).to be false
+        expect(inventory.has_instance_status?(hrid: hrid, status_id: status_id)).to be false
       end
     end
 
@@ -172,7 +172,7 @@ RSpec.describe FolioClient::Inventory do
       }
 
       it "returns false" do
-        expect(inventory.has_instance_status?(hrid:, status_id:)).to be false
+        expect(inventory.has_instance_status?(hrid: hrid, status_id: status_id)).to be false
       end
     end
 
@@ -183,7 +183,7 @@ RSpec.describe FolioClient::Inventory do
       }
 
       it "raises an error" do
-        expect { inventory.has_instance_status?(hrid:, status_id:) }.to raise_error(FolioClient::ResourceNotFound, "No matching instance found for #{hrid}")
+        expect { inventory.has_instance_status?(hrid: hrid, status_id: status_id) }.to raise_error(FolioClient::ResourceNotFound, "No matching instance found for #{hrid}")
       end
     end
   end

--- a/spec/folio_client/source_storage_spec.rb
+++ b/spec/folio_client/source_storage_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe FolioClient::SourceStorage do
   subject(:source_storage) { described_class.new(client) }
 
-  let(:args) { {url:, login_params:, okapi_headers:} }
+  let(:args) { {url: url, login_params: login_params, okapi_headers: okapi_headers} }
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }
@@ -109,7 +109,7 @@ RSpec.describe FolioClient::SourceStorage do
     }
 
     it "returns the parsed JSON as a hash for the one record that was found" do
-      result = source_storage.fetch_marc_hash(instance_hrid:)
+      result = source_storage.fetch_marc_hash(instance_hrid: instance_hrid)
       expect(result["fields"].select { |field_hash| field_hash.key?("001") }.map(&:values)).to eq([["a666"]])
       expect(result["fields"].select { |field_hash| field_hash.key?("008") }.map(&:values)).to eq([["750409s1961||||enk           ||| | eng  "]])
       expect(result["fields"].select { |field_hash| field_hash.key?("050") }.map(&:values)).to eq([[{"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "M231.B66 Bb maj. 1961"}]}]])
@@ -122,7 +122,7 @@ RSpec.describe FolioClient::SourceStorage do
     }
 
     it "raises a NotFound exception" do
-      expect { source_storage.fetch_marc_hash(instance_hrid:) }.to raise_error(FolioClient::ResourceNotFound, "No records found for #{instance_hrid}")
+      expect { source_storage.fetch_marc_hash(instance_hrid: instance_hrid) }.to raise_error(FolioClient::ResourceNotFound, "No records found for #{instance_hrid}")
     end
   end
 
@@ -200,7 +200,7 @@ RSpec.describe FolioClient::SourceStorage do
     }
 
     it "raises a MultipleRecordsForIdentifier exception" do
-      expect { source_storage.fetch_marc_hash(instance_hrid:) }.to raise_error(FolioClient::MultipleResourcesFound, "Expected 1 record for #{instance_hrid}, but found 2")
+      expect { source_storage.fetch_marc_hash(instance_hrid: instance_hrid) }.to raise_error(FolioClient::MultipleResourcesFound, "Expected 1 record for #{instance_hrid}, but found 2")
     end
   end
 end

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -5,13 +5,7 @@ RSpec.describe FolioClient do
     described_class.configure(**args)
   end
 
-  let(:args) do
-    {
-      url:,
-      login_params:,
-      okapi_headers:
-    }
-  end
+  let(:args) { {url: url, login_params: login_params, okapi_headers: okapi_headers} }
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }
@@ -74,12 +68,12 @@ RSpec.describe FolioClient do
     let(:barcode) { "123456" }
 
     before do
-      allow(described_class.instance).to receive(:fetch_hrid).with(barcode:)
+      allow(described_class.instance).to receive(:fetch_hrid).with(barcode: barcode)
     end
 
     it "invokes instance#fetch_hrid" do
-      client.fetch_hrid(barcode:)
-      expect(client.instance).to have_received(:fetch_hrid).with(barcode:)
+      client.fetch_hrid(barcode: barcode)
+      expect(client.instance).to have_received(:fetch_hrid).with(barcode: barcode)
     end
   end
 
@@ -88,12 +82,12 @@ RSpec.describe FolioClient do
     let(:status_id) { "1a2b3c4d-1234" }
 
     before do
-      allow(described_class.instance).to receive(:has_instance_status?).with(hrid:, status_id:)
+      allow(described_class.instance).to receive(:has_instance_status?).with(hrid: hrid, status_id: status_id)
     end
 
     it "invokes instance#has_instance_status?" do
-      client.has_instance_status?(hrid:, status_id:)
-      expect(client.instance).to have_received(:has_instance_status?).with(hrid:, status_id:)
+      client.has_instance_status?(hrid: hrid, status_id: status_id)
+      expect(client.instance).to have_received(:has_instance_status?).with(hrid: hrid, status_id: status_id)
     end
   end
 
@@ -108,7 +102,7 @@ RSpec.describe FolioClient do
     end
 
     it "invokes Inventory#has_instance_status?" do
-      client.public_send(:has_instance_status?, hrid:, status_id:)
+      client.public_send(:has_instance_status?, hrid: hrid, status_id: status_id)
       expect(inventory).to have_received(:has_instance_status?).once
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Some consumers of the folio client are still using ruby 3.0, so this makes the client ruby 3.0 compatible

## How was this change tested? 🤨

Updated tests