### PR TITLE
Extract JobStatus class from DataImport

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,10 @@ client.fetch_marc_hash(instance_hrid: "a7927874")
 
 # Import a MARC record
 data_importer = client.data_import(marc: my_marc, job_profile_id: '4ba4f4ab', job_profile_name: 'ETDs')
-data_importer.import
 # If called too quickly, might get Failure(:not_found)
-data_importer.job_status
+data_importer.status
  => Failure(:pending)
-data_importer.wait
+data_importer.wait_until_complete
  => Success()
 ```
 

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -101,21 +101,26 @@ class FolioClient
 
   # Public methods available on the FolioClient below
   def fetch_hrid(...)
-    inventory = Inventory.new(self)
-    inventory.fetch_hrid(...)
+    Inventory
+      .new(self)
+      .fetch_hrid(...)
   end
 
   def fetch_marc_hash(...)
-    source_storage = SourceStorage.new(self)
-    source_storage.fetch_marc_hash(...)
+    SourceStorage
+      .new(self)
+      .fetch_marc_hash(...)
   end
 
   def has_instance_status?(...)
-    inventory = Inventory.new(self)
-    inventory.has_instance_status?(...)
+    Inventory
+      .new(self)
+      .has_instance_status?(...)
   end
 
   def data_import(...)
-    DataImport.new(self, ...)
+    DataImport
+      .new(self, ...)
+      .import
   end
 end

--- a/lib/folio_client/data_import.rb
+++ b/lib/folio_client/data_import.rb
@@ -1,18 +1,12 @@
 # frozen_string_literal: true
 
-require "timeout"
 require "date"
-require "dry/monads"
 require "marc"
 require "stringio"
 
 class FolioClient
   # Imports MARC records into FOLIO
   class DataImport
-    include Dry::Monads[:result]
-
-    attr_reader :job_execution_id
-
     # @param client [FolioClient] the configured client
     # @param record [MARC::Record] record to be imported
     # @param job_profile_id [String] job profile id to use for import
@@ -27,44 +21,14 @@ class FolioClient
     def import
       response_hash = client.post("/data-import/uploadDefinitions", {fileDefinitions: [{name: marc_filename}]})
       upload_definition_id = response_hash.dig("fileDefinitions", 0, "uploadDefinitionId")
-      @job_execution_id = response_hash.dig("fileDefinitions", 0, "jobExecutionId")
+      job_execution_id = response_hash.dig("fileDefinitions", 0, "jobExecutionId")
       file_definition_id = response_hash.dig("fileDefinitions", 0, "id")
 
       upload_file_response_hash = client.post("/data-import/uploadDefinitions/#{upload_definition_id}/files/#{file_definition_id}", marc_binary(marc), content_type: "application/octet-stream")
 
       client.post("/data-import/uploadDefinitions/#{upload_definition_id}/processFiles",
         {uploadDefinition: upload_file_response_hash, jobProfileInfo: {id: job_profile_id, name: job_profile_name, dataType: "MARC"}})
-    end
-
-    # @return [Dry::Monads::Result] Success if job is complete,
-    # Failure(:pending) if job is still running,
-    # Failure(:error) if job has errors
-    # Failure(:not_found) if job is not found
-    def job_status
-      response_hash = client.get("/metadata-provider/jobSummary/#{job_execution_id}")
-
-      return Failure(:error) if response_hash["totalErrors"].positive?
-      return Failure(:pending) if response_hash.dig("sourceRecordSummary", "totalCreatedEntities").zero? && response_hash.dig("sourceRecordSummary", "totalUpdatedEntities").zero?
-      Success()
-    rescue ResourceNotFound
-      # Checking the status immediately after starting the import may result in a 404.
-      Failure(:not_found)
-    end
-
-    def wait(wait_secs: 1, timeout_secs: 5 * 60)
-      Timeout.timeout(timeout_secs) do
-        loop.with_index do |_, i|
-          result = job_status
-
-          # If a 404, wait a bit longer before raising an error.
-          check_not_found(result, i)
-          return result if done_waiting?(result)
-
-          sleep(wait_secs)
-        end
-      end
-    rescue Timeout::Error
-      Failure(:timeout)
+      JobStatus.new(client, job_execution_id: job_execution_id)
     end
 
     private
@@ -82,15 +46,6 @@ class FolioClient
         end
         io.string
       end
-    end
-
-    def done_waiting?(result)
-      result.success? || (result.failure? && result.failure == :error)
-    end
-
-    def check_not_found(result, index)
-      return unless result.failure? && result.failure == :not_found && index > 2
-      raise ResourceNotFound, "Job not found"
     end
   end
 end

--- a/lib/folio_client/job_status.rb
+++ b/lib/folio_client/job_status.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "timeout"
+require "dry/monads"
+
+class FolioClient
+  # Wraps operations waiting for results from jobs
+  class JobStatus
+    include Dry::Monads[:result]
+
+    attr_reader :job_execution_id
+
+    # @param client [FolioClient] the configured client
+    # @param job_execution_id [String] ID of the job to be checked on
+    def initialize(client, job_execution_id:)
+      @client = client
+      @job_execution_id = job_execution_id
+    end
+
+    # @return [Dry::Monads::Result] Success if job is complete,
+    # Failure(:pending) if job is still running,
+    # Failure(:error) if job has errors
+    # Failure(:not_found) if job is not found
+    def status
+      response_hash = client.get("/metadata-provider/jobSummary/#{job_execution_id}")
+
+      return Failure(:error) if response_hash["totalErrors"].positive?
+      return Failure(:pending) if response_hash.dig("sourceRecordSummary", "totalCreatedEntities").zero? && response_hash.dig("sourceRecordSummary", "totalUpdatedEntities").zero?
+
+      Success()
+    rescue ResourceNotFound
+      # Checking the status immediately after starting the import may result in a 404.
+      Failure(:not_found)
+    end
+
+    def wait_until_complete(wait_secs: 1, timeout_secs: 5 * 60)
+      Timeout.timeout(timeout_secs) do
+        loop.with_index do |_, i|
+          result = status
+
+          # If a 404, wait a bit longer before raising an error.
+          check_not_found(result, i)
+          return result if done_waiting?(result)
+
+          sleep(wait_secs)
+        end
+      end
+    rescue Timeout::Error
+      Failure(:timeout)
+    end
+
+    private
+
+    attr_reader :client
+
+    def done_waiting?(result)
+      result.success? || (result.failure? && result.failure == :error)
+    end
+
+    def check_not_found(result, index)
+      return unless result.failure? && result.failure == :not_found && index > 2
+
+      raise ResourceNotFound, "Job not found"
+    end
+  end
+end

--- a/spec/folio_client/job_status_spec.rb
+++ b/spec/folio_client/job_status_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+RSpec.describe FolioClient::JobStatus do
+  include Dry::Monads[:result]
+
+  let(:job_status) { described_class.new(client, job_execution_id: job_execution_id) }
+  let(:client) do
+    FolioClient.configure(
+      url: url,
+      login_params: {username: "username", password: "password"},
+      okapi_headers: {some_bogus_headers: "here"}
+    )
+  end
+  let(:job_execution_id) { "4ba4f4ab" }
+  let(:token) { "a_long_silly_token" }
+  let(:url) { "https://folio.example.org" }
+
+  before do
+    stub_request(:post, "#{url}/authn/login")
+      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+    allow(DateTime).to receive(:now).and_return(DateTime.parse("2023-03-01T11:17:25-05:00"))
+  end
+
+  describe "#job_execution_id" do
+    it "returns the job execution ID" do
+      expect(job_status.job_execution_id).to eq(job_execution_id)
+    end
+  end
+
+  describe "#status" do
+    before do
+      stub_request(:get, "#{url}/metadata-provider/jobSummary/#{job_execution_id}")
+        .with(
+          headers: {
+            "X-Okapi-Token" => "a_long_silly_token"
+          }
+        )
+        .to_return(status: status, body: status_response_body.to_json, headers: {})
+    end
+
+    let(:status) { 200 }
+
+    context "when job is pending" do
+      let(:status_response_body) do
+        {
+          jobExecutionId: job_execution_id,
+          totalErrors: 0,
+          sourceRecordSummary: {
+            totalCreatedEntities: 0,
+            totalUpdatedEntities: 0,
+            totalDiscardedEntities: 0,
+            totalErrors: 0
+          }
+        }
+      end
+
+      it "returns Failure(:pending)" do
+        expect(job_status.status).to eq(Failure(:pending))
+      end
+    end
+
+    context "when job error" do
+      let(:status_response_body) do
+        {
+          jobExecutionId: job_execution_id,
+          totalErrors: 1,
+          sourceRecordSummary: {
+            totalCreatedEntities: 0,
+            totalUpdatedEntities: 0,
+            totalDiscardedEntities: 0,
+            totalErrors: 1
+          }
+        }
+      end
+
+      it "returns Failure(:error)" do
+        expect(job_status.status).to eq(Failure(:error))
+      end
+    end
+
+    context "when job is complete" do
+      let(:status_response_body) do
+        {
+          jobExecutionId: job_execution_id,
+          totalErrors: 0,
+          sourceRecordSummary: {
+            totalCreatedEntities: 1,
+            totalUpdatedEntities: 0,
+            totalDiscardedEntities: 0,
+            totalErrors: 0
+          }
+        }
+      end
+
+      it "returns Success" do
+        expect(job_status.status).to eq(Success())
+      end
+    end
+
+    context "when job is not found" do
+      let(:status) { 404 }
+      let(:status_response_body) { "JobSummary for jobExecutionId: '#{job_execution_id}' was not found" }
+
+      it "returns Failure(:not_found)" do
+        expect(job_status.status).to eq(Failure(:not_found))
+      end
+    end
+  end
+
+  describe "#wait_until_complete" do
+    context "when job is complete" do
+      before do
+        allow(job_status).to receive(:status).and_return(Failure(:not_found), Failure(:pending), Success())
+      end
+
+      it "returns Success" do
+        expect(job_status.wait_until_complete(wait_secs: 0.1)).to eq(Success())
+        expect(job_status).to have_received(:status).exactly(3).times
+      end
+    end
+
+    context "when job is error" do
+      before do
+        allow(job_status).to receive(:status).and_return(Failure(:pending), Failure(:pending), Failure(:error))
+      end
+
+      it "returns Failure(:error)" do
+        expect(job_status.wait_until_complete(wait_secs: 0.1)).to eq(Failure(:error))
+        expect(job_status).to have_received(:status).exactly(3).times
+      end
+    end
+
+    context "when too many 404s" do
+      before do
+        allow(job_status).to receive(:status).and_return(Failure(:not_found))
+      end
+
+      it "raises ResourceNotFound" do
+        expect { job_status.wait_until_complete(wait_secs: 0.1) }.to raise_error(FolioClient::ResourceNotFound)
+        expect(job_status).to have_received(:status).exactly(4).times
+      end
+    end
+
+    context "when timeout" do
+      before do
+        allow(job_status).to receive(:status).and_return(Failure(:pending))
+      end
+
+      it "returns Failure(:timeout)" do
+        expect(job_status.wait_until_complete(wait_secs: 0.5, timeout_secs: 0.25)).to eq(Failure(:timeout))
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ SimpleCov.start do
   add_filter "spec"
 end
 
+require "byebug"
 require "folio_client"
 require "webmock/rspec"
 


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to #12

This spike commit refactors the client by extracting a reusable JobStatus class from the DataImport class, letting each class have a single responsibility. This arguably improves / simplifies the interaction in the following ways (see the README for more):

* Avoid the "yo dawg" situation where the consumer has to ask twice to run the import
* Instead of returning the client response from `DataImport#import`, return the `JobStatus` instance
* Rename `JobStatus#job_status` to `JobStatus#status`
* Rename `JobStatus#wait` to `JobStatus#wait_until_complete` (align with DSC's similar functionality)

## How was this change tested? 🤨

CI
