### PR TITLE
Add method to `JobStatus` class for retrieving an instance HRID

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ data_importer.status
  => Failure(:pending)
 data_importer.wait_until_complete
  => Success()
+data_importer.instance_hrid
+ => Success("in00000000010")
 ```
 
 ## Development

--- a/spec/folio_client/job_status_spec.rb
+++ b/spec/folio_client/job_status_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe FolioClient::JobStatus do
       stub_request(:get, "#{url}/metadata-provider/jobSummary/#{job_execution_id}")
         .with(
           headers: {
-            "X-Okapi-Token" => "a_long_silly_token"
+            "X-Okapi-Token" => token
           }
         )
         .to_return(status: status, body: status_response_body.to_json, headers: {})
@@ -148,6 +148,185 @@ RSpec.describe FolioClient::JobStatus do
 
       it "returns Failure(:timeout)" do
         expect(job_status.wait_until_complete(wait_secs: 0.5, timeout_secs: 0.25)).to eq(Failure(:timeout))
+      end
+    end
+  end
+
+  describe "#instance_hrid" do
+    before do
+      allow(job_status).to receive(:status).and_return(current_status)
+      allow(job_status).to receive(:default_timeout_secs).and_return(1)
+      stub_request(:get, "#{url}/metadata-provider/journalRecords/#{job_execution_id}")
+        .with(
+          headers: {
+            "X-Okapi-Token" => token
+          }
+        )
+        .to_return(status: status, body: journal_records_response.to_json, headers: {})
+    end
+
+    let(:current_status) { Success() }
+    let(:status) { 200 }
+    let(:journal_records_response) do
+      {
+        journalRecords: [
+          {
+            id: "ac01df37-1bec-4e61-bca8-d2932881c253",
+            jobExecutionId: "0087063f-73ff-4a52-8890-f318771963e4",
+            sourceId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+            sourceRecordOrder: 0,
+            entityType: "MARC_BIBLIOGRAPHIC",
+            entityId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+            entityHrId: "",
+            actionType: "CREATE",
+            actionStatus: "COMPLETED",
+            error: "",
+            title: "TEST5: TOPICS IN CONVEX OPTIMIZATION FOR MACHINE LEARNING / Youngsuk Park.",
+            actionDate: "2023-02-16T18:14:46.032+00:00"
+          },
+          {
+            id: "a61f5475-c612-4df2-8bec-e1775c06093d",
+            jobExecutionId: "0087063f-73ff-4a52-8890-f318771963e4",
+            sourceId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+            sourceRecordOrder: 0,
+            entityType: "MARC_BIBLIOGRAPHIC",
+            entityId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+            entityHrId: "",
+            actionType: "CREATE",
+            actionStatus: "COMPLETED",
+            error: "",
+            title: "TEST5: TOPICS IN CONVEX OPTIMIZATION FOR MACHINE LEARNING / Youngsuk Park.",
+            actionDate: "2023-02-16T18:14:53.323+00:00"
+          },
+          {
+            id: "1e699607-59a0-4620-a620-2004e49c3bb7",
+            jobExecutionId: "0087063f-73ff-4a52-8890-f318771963e4",
+            sourceId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+            sourceRecordOrder: 0,
+            entityType: "INSTANCE",
+            entityId: "45e401f8-ae58-42a5-9ccc-cc020cac7c3e",
+            entityHrId: "in00000000010",
+            actionType: "CREATE",
+            actionStatus: "COMPLETED",
+            error: "",
+            actionDate: "2023-02-16T18:14:53.444+00:00"
+          },
+          {
+            id: "45b2cec6-b681-4913-ac59-30bfdac1407d",
+            jobExecutionId: "0087063f-73ff-4a52-8890-f318771963e4",
+            sourceId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+            sourceRecordOrder: 0,
+            entityType: "HOLDINGS",
+            entityId: "f45c450f-d06c-452a-9e24-55551dcb2047",
+            instanceId: "45e401f8-ae58-42a5-9ccc-cc020cac7c3e",
+            entityHrId: "ho00000000008",
+            actionType: "CREATE",
+            actionStatus: "COMPLETED",
+            error: "",
+            title: "TEST5: TOPICS IN CONVEX OPTIMIZATION FOR MACHINE LEARNING / Youngsuk Park.",
+            actionDate: "2023-02-16T18:14:55.714+00:00"
+          }
+        ],
+        totalRecords: 4
+      }
+    end
+
+    it "returns Success with the instance HRID" do
+      expect(job_status.instance_hrid).to eq(Success("in00000000010"))
+    end
+
+    context "when current status is not successful" do
+      let(:current_status) { Failure(:pending) }
+
+      it "returns the current status" do
+        expect(job_status.instance_hrid).to eq(current_status)
+      end
+    end
+
+    context "when journal records request returns an error response" do
+      let(:journal_records_response) { {} }
+      let(:status) { 404 }
+
+      it "raises ResourceNotFound" do
+        expect { job_status.instance_hrid }.to raise_error(FolioClient::ResourceNotFound, /Endpoint not found/)
+      end
+    end
+
+    context "when journal records request returns no journal records" do
+      let(:journal_records_response) do
+        {
+          journalRecords: [],
+          totalRecords: 0
+        }
+      end
+
+      it "returns Failure indicating timeout" do
+        expect(job_status.instance_hrid).to eq(Failure(:timeout))
+      end
+    end
+
+    context "when journal records request returns empty response" do
+      let(:journal_records_response) { {} }
+
+      it "returns Failure indicating timeout" do
+        expect(job_status.instance_hrid).to eq(Failure(:timeout))
+      end
+    end
+
+    context "when journal records request does not include an INSTANCE type" do
+      let(:journal_records_response) do
+        {
+          journalRecords: [
+            {
+              id: "ac01df37-1bec-4e61-bca8-d2932881c253",
+              jobExecutionId: "0087063f-73ff-4a52-8890-f318771963e4",
+              sourceId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+              sourceRecordOrder: 0,
+              entityType: "MARC_BIBLIOGRAPHIC",
+              entityId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+              entityHrId: "",
+              actionType: "CREATE",
+              actionStatus: "COMPLETED",
+              error: "",
+              title: "TEST5: TOPICS IN CONVEX OPTIMIZATION FOR MACHINE LEARNING / Youngsuk Park.",
+              actionDate: "2023-02-16T18:14:46.032+00:00"
+            },
+            {
+              id: "a61f5475-c612-4df2-8bec-e1775c06093d",
+              jobExecutionId: "0087063f-73ff-4a52-8890-f318771963e4",
+              sourceId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+              sourceRecordOrder: 0,
+              entityType: "MARC_BIBLIOGRAPHIC",
+              entityId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+              entityHrId: "",
+              actionType: "CREATE",
+              actionStatus: "COMPLETED",
+              error: "",
+              title: "TEST5: TOPICS IN CONVEX OPTIMIZATION FOR MACHINE LEARNING / Youngsuk Park.",
+              actionDate: "2023-02-16T18:14:53.323+00:00"
+            },
+            {
+              id: "45b2cec6-b681-4913-ac59-30bfdac1407d",
+              jobExecutionId: "0087063f-73ff-4a52-8890-f318771963e4",
+              sourceId: "6faca97d-d081-4f19-8d2b-5e17ce32fd57",
+              sourceRecordOrder: 0,
+              entityType: "HOLDINGS",
+              entityId: "f45c450f-d06c-452a-9e24-55551dcb2047",
+              instanceId: "45e401f8-ae58-42a5-9ccc-cc020cac7c3e",
+              entityHrId: "ho00000000008",
+              actionType: "CREATE",
+              actionStatus: "COMPLETED",
+              error: "",
+              title: "TEST5: TOPICS IN CONVEX OPTIMIZATION FOR MACHINE LEARNING / Youngsuk Park.",
+              actionDate: "2023-02-16T18:14:55.714+00:00"
+            }
+          ],
+          totalRecords: 3
+        }
+      end
+
+      it "returns Failure indicating no instance HRID" do
+        expect(job_status.instance_hrid).to eq(Failure(:timeout))
       end
     end
   end


### PR DESCRIPTION
HOLD until I can test that the API actually behaves the way I've spec'ed this out.

## Why was this change made? 🤔

Fixes #12

This commit adds a new method, `JobStatus#instance_hrid`, that allows consumers to request retrieval of the instance HRID associated with the current job status as long as the status has already successfully completed. If not, a `Failure()` is returned. And if there is any trouble parsing an instance HRID out of the journal records of the job execution, a `Failure()` is returned indicating such.


## How was this change tested? 🤨

CI. Would be good to test this for real. Appreciate pointers on this!
