### PR TITLE
Add test coverage for missing FolioClient and UnexpectedResponse codeclimate

### DIFF
--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -120,7 +120,7 @@ class FolioClient
 
   def data_import(...)
     DataImport
-      .new(self, ...)
-      .import
+      .new(self)
+      .import(...)
   end
 end

--- a/lib/folio_client/data_import.rb
+++ b/lib/folio_client/data_import.rb
@@ -23,8 +23,18 @@ class FolioClient
 
       upload_file_response_hash = client.post("/data-import/uploadDefinitions/#{upload_definition_id}/files/#{file_definition_id}", marc_binary(marc), content_type: "application/octet-stream")
 
-      client.post("/data-import/uploadDefinitions/#{upload_definition_id}/processFiles",
-        {uploadDefinition: upload_file_response_hash, jobProfileInfo: {id: job_profile_id, name: job_profile_name, dataType: "MARC"}})
+      client.post(
+        "/data-import/uploadDefinitions/#{upload_definition_id}/processFiles",
+        {
+          uploadDefinition: upload_file_response_hash,
+          jobProfileInfo: {
+            id: job_profile_id,
+            name: job_profile_name,
+            dataType: "MARC"
+          }
+        }
+      )
+
       JobStatus.new(client, job_execution_id: job_execution_id)
     end
 

--- a/lib/folio_client/data_import.rb
+++ b/lib/folio_client/data_import.rb
@@ -8,17 +8,14 @@ class FolioClient
   # Imports MARC records into FOLIO
   class DataImport
     # @param client [FolioClient] the configured client
+    def initialize(client)
+      @client = client
+    end
+
     # @param record [MARC::Record] record to be imported
     # @param job_profile_id [String] job profile id to use for import
     # @param job_profile_name [String] job profile name to use for import
-    def initialize(client, marc:, job_profile_id:, job_profile_name:)
-      @client = client
-      @marc = marc
-      @job_profile_id = job_profile_id
-      @job_profile_name = job_profile_name
-    end
-
-    def import
+    def import(marc:, job_profile_id:, job_profile_name:)
       response_hash = client.post("/data-import/uploadDefinitions", {fileDefinitions: [{name: marc_filename}]})
       upload_definition_id = response_hash.dig("fileDefinitions", 0, "uploadDefinitionId")
       job_execution_id = response_hash.dig("fileDefinitions", 0, "jobExecutionId")

--- a/spec/folio_client/data_import_spec.rb
+++ b/spec/folio_client/data_import_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe FolioClient::DataImport do
-  let(:data_import) { described_class.new(client, marc: marc, job_profile_id: job_profile_id, job_profile_name: job_profile_name) }
+  let(:data_import) { described_class.new(client) }
   let(:args) { {url: url, login_params: login_params, okapi_headers: okapi_headers} }
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
@@ -129,7 +129,7 @@ RSpec.describe FolioClient::DataImport do
     end
 
     it "returns a JobStatus instance" do
-      expect(data_import.import).to be_instance_of(FolioClient::JobStatus)
+      expect(data_import.import(marc: marc, job_profile_id: job_profile_id, job_profile_name: job_profile_name)).to be_instance_of(FolioClient::JobStatus)
     end
   end
 end

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -127,6 +127,83 @@ RSpec.describe FolioClient do
     end
   end
 
+  describe "#fetch_hrid" do
+    let(:barcode) { "123456" }
+    let(:inventory) { instance_double(described_class::Inventory) }
+
+    before do
+      allow(described_class::Inventory).to receive(:new).and_return(inventory)
+      allow(inventory).to receive(:fetch_hrid)
+    end
+
+    it "invokes Inventory#fetch_hrid" do
+      client.fetch_hrid(barcode: barcode)
+      expect(inventory).to have_received(:fetch_hrid).once
+    end
+  end
+
+  describe ".fetch_marc_hash" do
+    let(:instance_hrid) { "a12854819" }
+
+    before do
+      allow(described_class.instance).to receive(:fetch_marc_hash).with(instance_hrid: instance_hrid)
+    end
+
+    it "invokes instance#fetch_marc_hash" do
+      client.fetch_marc_hash(instance_hrid: instance_hrid)
+      expect(client.instance).to have_received(:fetch_marc_hash).with(instance_hrid: instance_hrid)
+    end
+  end
+
+  describe "#fetch_marc_hash" do
+    let(:instance_hrid) { "123456" }
+    let(:source_storage) { instance_double(described_class::SourceStorage) }
+
+    before do
+      allow(described_class::SourceStorage).to receive(:new).and_return(source_storage)
+      allow(source_storage).to receive(:fetch_marc_hash)
+    end
+
+    it "invokes SourceStorage#fetch_marc_hash" do
+      client.fetch_marc_hash(instance_hrid: instance_hrid)
+      expect(source_storage).to have_received(:fetch_marc_hash).once
+    end
+  end
+
+  describe ".data_import" do
+    let(:job_profile_id) { "4ba4f4ab" }
+    let(:job_profile_name) { "ETDs" }
+    let(:marc) { instance_double(MARC::Record) }
+
+    before do
+      allow(described_class.instance).to receive(:data_import)
+        .with(job_profile_id: job_profile_id, job_profile_name: job_profile_name, marc: marc)
+    end
+
+    it "invokes instance#data_import" do
+      client.data_import(job_profile_id: job_profile_id, job_profile_name: job_profile_name, marc: marc)
+      expect(client.instance).to have_received(:data_import)
+        .with(job_profile_id: job_profile_id, job_profile_name: job_profile_name, marc: marc)
+    end
+  end
+
+  describe "#data_import" do
+    let(:job_profile_id) { "4ba4f4ab" }
+    let(:job_profile_name) { "ETDs" }
+    let(:marc) { instance_double(MARC::Record) }
+    let(:importer) { instance_double(described_class::DataImport) }
+
+    before do
+      allow(described_class::DataImport).to receive(:new).and_return(importer)
+      allow(importer).to receive(:import)
+    end
+
+    it "invokes DataImport#import" do
+      client.data_import(job_profile_id: job_profile_id, job_profile_name: job_profile_name, marc: marc)
+      expect(importer).to have_received(:import).once
+    end
+  end
+
   describe ".has_instance_status?" do
     let(:hrid) { "a12854819" }
     let(:status_id) { "1a2b3c4d-1234" }


### PR DESCRIPTION
## Why was this change made? 🤔

Coverage of key code was missing.

And, in so doing, opportunistically simplify and regularize, including:
* Change the internal structure of `FolioClient#data_import` such that instantiation takes only the client, with other args passed to the `DataImport#import` method, which brings consistency with the other methods in the client
* Tweak structure of the authenticator spec such that `describe`s are outside of `context`s instead of vice versa, which is typically what we do in other codebases, and also trims lines of code from the spec (less noise).
* Use `let()` variables in authenticator spec to give names to bits that vary between tests
* Cover the `ForbiddenError`, `ServiceUnavailable`, and `StandardError` branches in `UnexpectedResponse`

## How was this change tested? 🤨

CI
