### PR TITLE
Adds create holdings. Fix handling of 422 response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ data_importer.wait_until_complete
  => Success()
 data_importer.instance_hrid
  => Success("in00000000010")
+
+# Create a Holdings record
+holdings_client = client.holdings(instance_id: "99a6d818-d523-42f3-9844-81cf3187dbad")
+holdings_client.create(permanent_location_id: "1b14e21c-8d47-45c7-bc49-456a0086422b", holdings_type_id: "996f93e2-5b5e-4cf2-9168-33ced1f95eed")
+ => {
+    "id" => "581f6289-001f-49d1-bab7-035f4d878cbd",
+    "_version" => 1,
+    "hrid" => "ho00000000065",
+    "holdingsTypeId" => "996f93e2-5b5e-4cf2-9168-33ced1f95eed"
+    ...
+ }
 ```
 
 ## Development

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -17,7 +17,7 @@ class FolioClient
   # Base class for all FolioClient errors
   class Error < StandardError; end
 
-  # Error raised by the Folio Auth API returns a 422 Unauthorized
+  # Error raised by the Folio Auth API returns a 401 Unauthorized
   class UnauthorizedError < Error; end
 
   # Error raised when the Folio API returns a 404 NotFound, or returns 0 results when one was expected
@@ -31,6 +31,9 @@ class FolioClient
 
   # Error raised when the Folio API returns a 500
   class ServiceUnavailable < Error; end
+
+  # Error raised when the Folio API returns a 422 Unprocessable Entity
+  class ValidationError < Error; end
 
   DEFAULT_HEADERS = {
     accept: "application/json, text/plain",
@@ -50,7 +53,7 @@ class FolioClient
     end
 
     delegate :config, :connection, :get, :post, to: :instance
-    delegate :fetch_hrid, :fetch_marc_hash, :has_instance_status?, :data_import, to: :instance
+    delegate :fetch_hrid, :fetch_marc_hash, :has_instance_status?, :data_import, :holdings, to: :instance
   end
 
   attr_accessor :config
@@ -122,5 +125,10 @@ class FolioClient
     DataImport
       .new(self)
       .import(...)
+  end
+
+  def holdings(...)
+    Holdings
+      .new(self, ...)
   end
 end

--- a/lib/folio_client/holdings.rb
+++ b/lib/folio_client/holdings.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class FolioClient
+  # Manage holdings records in the Folio inventory
+  class Holdings
+    attr_accessor :client, :instance_id
+
+    # @param client [FolioClient] the configured client
+    # @param instance_id [String] the UUID of the instance to which the holdings records belongs
+    def initialize(client, instance_id:)
+      @client = client
+      @instance_id = instance_id
+    end
+
+    # @param permanent_location_id [String] the UUID of the permanent location
+    # @param holdings_type_id [String] the UUID of the holdings type
+    def create(holdings_type_id:, permanent_location_id:)
+      client.post("/holdings-storage/holdings", {
+        instanceId: instance_id,
+        permanentLocationId: permanent_location_id,
+        holdingsTypeId: holdings_type_id
+      })
+    end
+  end
+end

--- a/lib/folio_client/unexpected_response.rb
+++ b/lib/folio_client/unexpected_response.rb
@@ -13,7 +13,7 @@ class FolioClient
       when 404
         raise ResourceNotFound, "Endpoint not found or resource does not exist: #{response.body}"
       when 422
-        raise UnauthorizedError, "There was a problem fetching the access token: #{response.body} "
+        raise ValidationError, "There was a validation problem with the request: #{response.body} "
       when 500
         raise ServiceUnavailable, "The remote server returned an internal server error."
       else

--- a/spec/folio_client/authenticator_spec.rb
+++ b/spec/folio_client/authenticator_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe FolioClient::Authenticator do
     end
 
     context "when incorrect credentials" do
-      let(:http_status) { 422 }
+      let(:http_status) { 401 }
       let(:http_body) { "{\"error\" : \"get bent\"}" }
 
       it "raises an unauthorized error" do

--- a/spec/folio_client/holdings_spec.rb
+++ b/spec/folio_client/holdings_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe FolioClient::Holdings do
+  let(:holdings_client) { described_class.new(client, instance_id: instance_id) }
+  let(:args) { {url: url, login_params: login_params, okapi_headers: okapi_headers} }
+  let(:url) { "https://folio.example.org" }
+  let(:login_params) { {username: "username", password: "password"} }
+  let(:okapi_headers) { {some_bogus_headers: "here"} }
+  let(:token) { "a_long_silly_token" }
+  let(:client) { FolioClient.configure(**args) }
+
+  let(:instance_id) { "99a6d818-d523-42f3-9844-81cf3187dbad" }
+  let(:holdings_type_id) { "996f93e2-5b5e-4cf2-9168-33ced1f95eed" }
+  let(:permanent_location_id) { "1b14e21c-8d47-45c7-bc49-456a0086422b" }
+
+  before do
+    stub_request(:post, "#{url}/authn/login")
+      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+    allow(DateTime).to receive(:now).and_return(DateTime.parse("2023-03-01T11:17:25-05:00"))
+  end
+
+  describe ".create" do
+    let(:create) { holdings_client.create(permanent_location_id: permanent_location_id, holdings_type_id: holdings_type_id) }
+
+    context "when successful" do
+      let(:response_body) do
+        {
+          "id" => "581f6289-001f-49d1-bab7-035f4d878cbd",
+          "_version" => 1,
+          "hrid" => "ho00000000065",
+          "holdingsTypeId" => "996f93e2-5b5e-4cf2-9168-33ced1f95eed"
+        }
+      end
+
+      before do
+        stub_request(:post, "#{url}/holdings-storage/holdings")
+          .with(
+            body: {
+              instanceId: instance_id,
+              permanentLocationId: permanent_location_id,
+              holdingsTypeId: holdings_type_id
+            }.to_json
+          )
+          .to_return(status: 201, body: response_body.to_json)
+      end
+
+      it "returns response body" do
+        expect(create).to eq(response_body)
+      end
+    end
+
+    context "when error" do
+      let(:response_body) do
+        {errors: [{message: "Cannot set holdings_record.permanentlocationid = 1b14e21c-8d47-45c7-bc49-456a0086422c because it does not exist in location.id.",
+                   type: "1",
+                   code: "-1",
+                   parameters: [{key: "holdings_record.permanentlocationid",
+                                 value: "1b14e21c-8d47-45c7-bc49-456a0086422c"}]}]}
+      end
+
+      before do
+        stub_request(:post, "#{url}/holdings-storage/holdings")
+          .with(
+            body: {
+              instanceId: instance_id,
+              permanentLocationId: permanent_location_id,
+              holdingsTypeId: holdings_type_id
+            }.to_json
+          )
+          .to_return(status: 422, body: response_body.to_json)
+      end
+
+      it "raise" do
+        expect { create }.to raise_error(FolioClient::ValidationError, /Cannot set holdings_record.permanentlocationid/)
+      end
+    end
+  end
+end

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -297,4 +297,33 @@ RSpec.describe FolioClient do
         .to(new_token)
     end
   end
+
+  describe ".holdings" do
+    let(:instance_id) { "99a6d818-d523-42f3-9844-81cf3187dbad" }
+
+    before do
+      allow(described_class.instance).to receive(:holdings)
+        .with(instance_id: instance_id)
+    end
+
+    it "invokes instance#holdings" do
+      client.holdings(instance_id: instance_id)
+      expect(client.instance).to have_received(:holdings)
+        .with(instance_id: instance_id)
+    end
+  end
+
+  describe "#holdings" do
+    let(:instance_id) { "99a6d818-d523-42f3-9844-81cf3187dbad" }
+    let(:holdings_client) { instance_double(described_class::Holdings) }
+
+    before do
+      allow(described_class::Holdings).to receive(:new).and_return(holdings_client)
+    end
+
+    it "returns new Holdings" do
+      client.holdings(instance_id: instance_id)
+      expect(described_class::Holdings).to have_received(:new).with(client, instance_id: instance_id)
+    end
+  end
 end


### PR DESCRIPTION
closes #39

## Why was this change made? 🤔
Creating holding records is needed as part of the publish process.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Local, unit