### PR TITLE
Update marc records via quick-marc, using optimistic locking to prevent accidental overwrites

### DIFF
--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -53,7 +53,7 @@ class FolioClient
     end
 
     delegate :config, :connection, :get, :post, :put, to: :instance
-    delegate :fetch_hrid, :fetch_external_id, :fetch_instance_info, :fetch_marc_hash, :has_instance_status?, :data_import, :holdings, to: :instance
+    delegate :fetch_hrid, :fetch_external_id, :fetch_instance_info, :fetch_marc_hash, :has_instance_status?, :data_import, :holdings, :edit_marc_json, to: :instance
   end
 
   attr_accessor :config
@@ -163,5 +163,11 @@ class FolioClient
   def holdings(...)
     Holdings
       .new(self, ...)
+  end
+
+  def edit_marc_json(...)
+    RecordsEditor
+      .new(self)
+      .edit_marc_json(...)
   end
 end

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -53,7 +53,7 @@ class FolioClient
     end
 
     delegate :config, :connection, :get, :post, :put, to: :instance
-    delegate :fetch_hrid, :fetch_marc_hash, :has_instance_status?, :data_import, :holdings, to: :instance
+    delegate :fetch_hrid, :fetch_external_id, :fetch_instance_info, :fetch_marc_hash, :has_instance_status?, :data_import, :holdings, to: :instance
   end
 
   attr_accessor :config
@@ -128,6 +128,18 @@ class FolioClient
     Inventory
       .new(self)
       .fetch_hrid(...)
+  end
+
+  def fetch_external_id(...)
+    Inventory
+      .new(self)
+      .fetch_external_id(...)
+  end
+
+  def fetch_instance_info(...)
+    Inventory
+      .new(self)
+      .fetch_instance_info(...)
   end
 
   def fetch_marc_hash(...)

--- a/lib/folio_client/inventory.rb
+++ b/lib/folio_client/inventory.rb
@@ -24,6 +24,33 @@ class FolioClient
       result.dig("hrid")
     end
 
+    # @param hrid [String] HRID to search by to fetch the external ID
+    # @return [String,nil] external ID if present, otherwise nil.
+    # @raise [ResourceNotFound, MultipleResourcesFound] if search does not return exactly 1 result
+    def fetch_external_id(hrid:)
+      instance_response = client.get("/search/instances", {query: "hrid==#{hrid}"})
+      record_count = instance_response["totalRecords"]
+      raise ResourceNotFound, "No matching instance found for #{hrid}" if instance_response["totalRecords"] == 0
+      raise MultipleResourcesFound, "Expected 1 record for #{hrid}, but found #{record_count}" if record_count > 1
+
+      instance_response.dig("instances", 0, "id")
+    end
+
+    # Retrieve basic information about a record.  Example usage: get the external ID and _version for update using
+    #  optimistic locking when the HRID is available: `fetch_instance_info(hrid: 'a1234').slice('id', '_version')`
+    #  (or vice versa if the external ID is available).
+    # @param external_id [String] an external ID for looking up info about the record
+    # @param hrid [String] an HRID for looking up info about the record
+    # @return [Hash] information about the record.
+    # @raise [ArgumentError] if the caller does not provide exactly one of external_id or hrid
+    def fetch_instance_info(external_id: nil, hrid: nil)
+      raise ArgumentError, "must pass exactly one of external_id or HRID" unless external_id.present? || hrid.present?
+      raise ArgumentError, "must pass exactly one of external_id or HRID" if external_id.present? && hrid.present?
+
+      external_id ||= fetch_external_id(hrid: hrid)
+      client.get("/inventory/instances/#{external_id}")
+    end
+
     # @param hrid [String] folio instance HRID
     # @param status_id [String] uuid for an instance status code
     # @raise [ResourceNotFound] if search by hrid returns 0 results

--- a/lib/folio_client/records_editor.rb
+++ b/lib/folio_client/records_editor.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class FolioClient
+  class RecordsEditor
+    attr_accessor :client
+
+    # @param client [FolioClient] the configured client
+    def initialize(client)
+      @client = client
+    end
+
+    # Given an HRID, retrieves the associated MARC JSON, yields it to the caller as a hash,
+    # and attempts to re-save it, using optimistic locking to prevent accidental overwrite,
+    # in case another user or process has updated the record in the time between retrieval and
+    # attempted save.
+    # @param hrid [String] the HRID of the MARC record to be edited and saved
+    # @yieldparam record_json [Hash] a hash representation of the MARC JSON for the
+    #  HRID; the updated hash will be saved when control is returned from the block.
+    # @note in limited manual testing, optimistic locking behaved like so when two edit attempts collided:
+    #   * One updating client would eventually raise a timeout.  This updating client would actually write successfully, and version the record.
+    #   * The other updating client would raise a StandardError, with a message like 'duplicate key value violates unique constraint \"idx_records_matched_id_gen\"'.
+    #     This client would fail to write.
+    #   * As opposed to the expected behavior of the "winner" getting a 200 ok response, and the "loser" getting a 409 conflict response.
+    # @todo If this is a problem in practice, see if it's possible to have Folio respond in a more standard way; or, workaround with error handling.
+    def edit_marc_json(hrid:)
+      instance_info = client.fetch_instance_info(hrid: hrid)
+
+      version = instance_info["_version"]
+      external_id = instance_info["id"]
+
+      record_json = client.get("/records-editor/records", {externalId: external_id})
+
+      parsed_record_id = record_json["parsedRecordId"]
+      record_json["relatedRecordVersion"] = version # setting this field on the JSON we send back is what will allow optimistic locking to catch stale updates
+
+      yield record_json
+
+      client.put("/records-editor/records/#{parsed_record_id}", record_json)
+    end
+  end
+end

--- a/spec/folio_client/inventory_spec.rb
+++ b/spec/folio_client/inventory_spec.rb
@@ -187,4 +187,110 @@ RSpec.describe FolioClient::Inventory do
       end
     end
   end
+
+  describe "#fetch_external_id" do
+    let(:hrid) { "in00000000067" }
+    let(:external_id) { "5108040a-65bc-40ed-bd50-265958301ce4" }
+    let(:search_instance_response) do
+      {"totalRecords" => 1,
+       "instances" =>
+        [{"id" => external_id,
+          "title" => "TOPICS IN CONVEX OPTIMIZATION FOR MACHINE LEARNING / Youngsuk Park.",
+          "contributors" => [{"name" => "Park, Youngsuk,", "contributorNameTypeId" => "2b94c631-fca9-4892-a730-03ee529ffe2a", "primary" => true}],
+          "publication" => [{"publisher" => "[Stanford University]", "dateOfPublication" => "2020"}, {"dateOfPublication" => "©2020"}],
+          "discoverySuppress" => false,
+          "isBoundWith" => false,
+          "electronicAccess" => [],
+          "notes" => [],
+          "items" => [],
+          "holdings" => []}]}
+    end
+
+    before do
+      stub_request(:get, "#{url}/search/instances?query=hrid==#{hrid}")
+        .to_return(status: 200, body: search_instance_response.to_json)
+    end
+
+    it "returns the external_id for the HRID when there is one result found" do
+      expect(inventory.fetch_external_id(hrid: hrid)).to eq(external_id)
+    end
+
+    context "when no results are found" do
+      let(:search_instance_response) do
+        {"totalRecords" => 0,
+         "instances" => []}
+      end
+
+      it "raises ResourceNotFound" do
+        expect { inventory.fetch_external_id(hrid: hrid) }.to raise_error(FolioClient::ResourceNotFound, "No matching instance found for #{hrid}")
+      end
+    end
+
+    context "when multiple results are found" do
+      let(:search_instance_response) do
+        {"totalRecords" => 2,
+         "instances" => [nil, nil]}
+      end
+
+      it "raises MultipleResourcesFound" do
+        expect { inventory.fetch_external_id(hrid: hrid) }.to raise_error(FolioClient::MultipleResourcesFound, "Expected 1 record for #{hrid}, but found 2")
+      end
+    end
+  end
+
+  describe "#fetch_instance_info" do
+    let(:hrid) { "in00000000067" }
+    let(:external_id) { "5108040a-65bc-40ed-bd50-265958301ce4" }
+    let(:instance_info_response) do
+      {"id" => "5108040a-65bc-40ed-bd50-265958301ce4",
+       "_version" => "18",
+       "hrid" => "in00000000067",
+       "source" => "MARC",
+       "title" => "TOPICS IN CONVEX OPTIMIZATION FOR MACHINE LEARNING / Youngsuk Park.",
+       "administrativeNotes" => ["https://etd.stanford.edu/view/0000007573"],
+       "identifiers" => [{"identifierTypeId" => "7e591197-f335-4afb-bc6d-a6d76ca3bace", "value" => "dorcg532dg5405"}],
+       "contributors" =>
+        [{"contributorNameTypeId" => "2b94c631-fca9-4892-a730-03ee529ffe2a", "name" => "Park, Youngsuk,", "contributorTypeText" => "author.", "primary" => true}],
+       "instanceTypeId" => "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
+       "languages" => ["eng"],
+       "notes" =>
+        [{"instanceNoteTypeId" => "6a2533a7-4de2-4e64-8466-074c2fa9308c", "note" => "Submitted to the Department of Electrical Engineering", "staffOnly" => false}],
+       "statusId" => "26f5208e-110a-4394-be29-1569a8c84a65",
+       "statusUpdatedDate" => "2023-03-02T14:12:30.101+0000",
+       "metadata" =>
+        {"createdDate" => "2023-03-02T14:12:30.100+00:00", "createdByUserId" => "297649ab-3f9e-5ece-91a3-25cf700062ae",
+         "updatedDate" => "2023-03-14T04:44:48.683+00:00", "updatedByUserId" => "297649ab-3f9e-5ece-91a3-25cf700062ae"}}
+    end
+    let(:search_instance_response) do
+      {"totalRecords" => 1,
+       "instances" =>
+        [{"id" => external_id,
+          "title" => "TOPICS IN CONVEX OPTIMIZATION FOR MACHINE LEARNING / Youngsuk Park.",
+          "contributors" => [{"name" => "Park, Youngsuk,", "contributorNameTypeId" => "2b94c631-fca9-4892-a730-03ee529ffe2a", "primary" => true}],
+          "publication" => [{"publisher" => "[Stanford University]", "dateOfPublication" => "2020"}, {"dateOfPublication" => "©2020"}]}]}
+    end
+
+    before do
+      stub_request(:get, "#{url}/search/instances?query=hrid==#{hrid}")
+        .to_return(status: 200, body: search_instance_response.to_json)
+      stub_request(:get, "#{url}/inventory/instances/#{external_id}")
+        .to_return(status: 200, body: instance_info_response.to_json)
+    end
+
+    it "fetches info about the inventory instance if given an external ID for an extant record" do
+      expect(inventory.fetch_instance_info(external_id: external_id)).to eq(instance_info_response)
+    end
+
+    it "fetches info about the inventory instance if given an HRID for an extant record" do
+      expect(inventory.fetch_instance_info(hrid: hrid)).to eq(instance_info_response)
+    end
+
+    it "raises an error if neither type of ID is provided" do
+      expect { inventory.fetch_instance_info }.to raise_error(ArgumentError, "must pass exactly one of external_id or HRID")
+    end
+
+    it "raises an error if both types of ID are provided" do
+      expect { inventory.fetch_instance_info(external_id: external_id, hrid: hrid) }.to raise_error(ArgumentError, "must pass exactly one of external_id or HRID")
+    end
+  end
 end

--- a/spec/folio_client/records_editor_spec.rb
+++ b/spec/folio_client/records_editor_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+RSpec.describe FolioClient::RecordsEditor do
+  subject(:records_editor) { described_class.new(client) }
+
+  let(:args) { {url: url, login_params: login_params, okapi_headers: okapi_headers} }
+  let(:url) { "https://folio.example.org" }
+  let(:login_params) { {username: "username", password: "password"} }
+  let(:okapi_headers) { {some_bogus_headers: "here"} }
+  let(:token) { "aLongSTring.eNCodinga.JwTeeeee" }
+  let(:client) { FolioClient.configure(**args) }
+  let(:hrid) { "in00000000067" }
+  let(:external_id) { "5108040a-65bc-40ed-bd50-265958301ce4" }
+
+  let(:mock_response_json) do
+    {"parsedRecordId" => "1ab23862-46db-4da9-af5b-633adbf5f90f",
+     "parsedRecordDtoId" => "1281ae0b-548b-49e3-b740-050f28e6d57f",
+     "suppressDiscovery" => false,
+     "marcFormat" => "BIBLIOGRAPHIC",
+     "externalId" => "5108040a-65bc-40ed-bd50-265958301ce4",
+     "externalHrid" => "in00000000067",
+     "leader" => "01654nam\\a22003253i\\4500",
+     "fields" =>
+      [{"tag" => "001", "content" => "in00000000067", "isProtected" => true},
+        {"tag" => "006", "content" => {"Type" => "m", "Audn" => "\\", "Form" => "\\", "File" => "d", "GPub" => "\\"}, "isProtected" => false},
+        {"tag" => "007",
+         "content" =>
+          {"$categoryName" => "Electronic resource", "Category" => "c", "SMD" => "r",
+           "Color" => "u", "Dimensions" => "n", "Sound" => "\\", "Image bit depth" => "\\\\\\", "File formats" => "\\", "Quality assurance target(s)" => "\\",
+           "Antecedent/ Source" => "\\", "Level of compression" => "\\", "Reformatting quality" => "\\"},
+         "isProtected" => false},
+        {"tag" => "008",
+         "content" =>
+          {"Type" => "a", "BLvl" => "m", "Entered" => "200417", "DtSt" => "t", "Date1" => "2020", "Date2" => "2020",
+           "Ctry" => "cau", "Lang" => "eng", "MRec" => "\\", "Srce" => "d",
+           "Ills" => ["\\", "\\", "\\", "\\"], "Audn" => "\\", "Form" => "o", "Cont" => ["m", "\\", "\\", "\\"],
+           "GPub" => "\\", "Conf" => "0", "Fest" => "0", "Indx" => "0", "LitF" => "0", "Biog" => "\\"},
+         "isProtected" => false},
+        {"tag" => "005", "content" => "20230303155934.8", "isProtected" => false},
+        {"tag" => "035", "content" => "$a dorcg532dg5405", "indicators" => ["\\", "\\"], "isProtected" => false},
+        {"tag" => "040", "content" => "$a CSt $b eng $e rda $c CSt", "indicators" => ["\\", "\\"], "isProtected" => false},
+        {"tag" => "100", "content" => "$a Name, Author, $e author.", "indicators" => ["1", "\\"], "isProtected" => false},
+        {"tag" => "245",
+         "content" => "$a Original Title: Before Update / $c Author Name.",
+         "indicators" => ["1", "0"],
+         "isProtected" => false},
+        {"tag" => "264",
+         "content" => "$a [Stanford, California] : $b [Stanford University], $c 2020.",
+         "indicators" => ["\\", "1"],
+         "isProtected" => false},
+        {"tag" => "264", "content" => "$c ©2020", "indicators" => ["\\", "4"], "isProtected" => false},
+        {"tag" => "300", "content" => "$a 1 online resource.", "indicators" => ["\\", "\\"], "isProtected" => false},
+        {"tag" => "336", "content" => "$a text $2 rdacontent", "indicators" => ["\\", "\\"], "isProtected" => false},
+        {"tag" => "337", "content" => "$a computer $2 rdamedia", "indicators" => ["\\", "\\"], "isProtected" => false},
+        {"tag" => "338", "content" => "$a online resource $2 rdacarrier", "indicators" => ["\\", "\\"], "isProtected" => false},
+        {"tag" => "520",
+         "content" => "$a Convex optimization has been well-studied as a mathematical topic for more than a century, and has been applied in practice in many application areas for about a half century in fields including control, finance, signal processing, data mining, and machine learning. This thesis focuses on several topics involving convex optimization, with the specific application of machine learning.",
+         "indicators" => ["3", "\\"],
+         "isProtected" => false},
+        {"tag" => "700",
+         "content" => "$a Boyd, Stephen, $e degree supervisor. $4 ths",
+         "indicators" => ["1", "\\"],
+         "isProtected" => false},
+        {"tag" => "700",
+         "content" => "$a Leskovec, Jure, $e degree committee member. $4 ths",
+         "indicators" => ["1", "\\"],
+         "isProtected" => false},
+        {"tag" => "710",
+         "content" => "$a Stanford University. $b Department of Electrical Engineering.",
+         "indicators" => ["2", "\\"],
+         "isProtected" => false},
+        {"tag" => "856", "content" => "$u https://purl.stanford.edu/cg532dg5405", "indicators" => ["4", "0"], "isProtected" => false},
+        {"tag" => "910", "content" => "$a https://etd.stanford.edu/view/0000007573", "indicators" => ["\\", "\\"], "isProtected" => true},
+        {"tag" => "999",
+         "content" => "$s 1281ae0b-548b-49e3-b740-050f28e6d57f $i 5108040a-65bc-40ed-bd50-265958301ce4",
+         "indicators" => ["f", "f"],
+         "isProtected" => true}],
+     "updateInfo" =>
+      {"recordState" => "ERROR",
+       "updateDate" => "2023-03-03T15:59:35.511Z",
+       "updatedBy" =>
+        {"userId" => "297649ab-3f9e-5ece-91a3-25cf700062ae", "username" => "app_sdr", "firstName" => "sdr", "lastName" => "App"}}}
+  end
+
+  before do
+    stub_request(:post, "#{url}/authn/login")
+      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+    allow(client).to receive(:fetch_instance_info).with(hrid: hrid).and_return({"_version" => 1, "id" => external_id})
+    allow(client).to receive(:get).with("/records-editor/records", {externalId: external_id}).and_return(mock_response_json)
+    allow(client).to receive(:put)
+  end
+
+  it "obtains the MARC JSON, yields it to the caller, and PUTs the edited JSON back to Folio (inserting version for optimistic locking)" do # rubocop:disable RSpec/ExampleLength
+    records_editor.edit_marc_json(hrid: hrid) do |editable_response_json|
+      expect(editable_response_json).to eq mock_response_json
+      editable_response_json["fields"].detect { |field| field["tag"] == "245" }["content"] = "$a title updated by unit test / $c Author Name."
+    end
+    expect(client).to have_received(:put).with(
+      "/records-editor/records/#{mock_response_json["parsedRecordId"]}",
+      hash_including({"parsedRecordId" => "1ab23862-46db-4da9-af5b-633adbf5f90f",
+        "parsedRecordDtoId" => "1281ae0b-548b-49e3-b740-050f28e6d57f",
+        "relatedRecordVersion" => 1,
+        "externalId" => "5108040a-65bc-40ed-bd50-265958301ce4",
+        "externalHrid" => "in00000000067",
+        "fields" => array_including({"tag" => "245", "content" => "$a title updated by unit test / $c Author Name.", "indicators" => ["1", "0"], "isProtected" => false})})
+    )
+  end
+end

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -206,6 +206,70 @@ RSpec.describe FolioClient do
     end
   end
 
+  describe ".fetch_external_id" do
+    let(:hrid) { "in00000000067" }
+    let(:external_id) { "5108040a-65bc-40ed-bd50-265958301ce4" }
+
+    before do
+      allow(described_class.instance).to receive(:fetch_external_id).with(hrid: hrid).and_return(external_id)
+    end
+
+    it "invokes instance#fetch_external_id and passes along the return value" do
+      expect(client.fetch_external_id(hrid: hrid)).to eq external_id
+      expect(client.instance).to have_received(:fetch_external_id).with(hrid: hrid)
+    end
+  end
+
+  describe "#fetch_external_id" do
+    let(:hrid) { "in00000000067" }
+    let(:inventory) { instance_double(described_class::Inventory) }
+    let(:external_id) { "5108040a-65bc-40ed-bd50-265958301ce4" }
+
+    before do
+      allow(described_class::Inventory).to receive(:new).with(client).and_return(inventory)
+      allow(inventory).to receive(:fetch_external_id).with(hrid: hrid).and_return(external_id)
+    end
+
+    it "invokes Inventory#fetch_external_id and passes along the return value" do
+      expect(client.fetch_external_id(hrid: hrid)).to eq external_id
+      expect(inventory).to have_received(:fetch_external_id).once
+    end
+  end
+
+  describe ".fetch_instance_info" do
+    let(:external_id) { "5108040a-65bc-40ed-bd50-265958301ce4" }
+    let(:instance_info) do
+      {"id" => external_id, "version" => 2, "hrid" => "in00000000010"}
+    end
+
+    before do
+      allow(described_class.instance).to receive(:fetch_instance_info).with(external_id: external_id).and_return(instance_info)
+    end
+
+    it "invokes instance#fetch_instance_info and passes along the return value" do
+      expect(client.fetch_instance_info(external_id: external_id)).to eq instance_info
+      expect(client.instance).to have_received(:fetch_instance_info).with(external_id: external_id)
+    end
+  end
+
+  describe "#fetch_instance_info" do
+    let(:external_id) { "5108040a-65bc-40ed-bd50-265958301ce4" }
+    let(:inventory) { instance_double(described_class::Inventory) }
+    let(:instance_info) do
+      {"id" => external_id, "version" => 2, "hrid" => "in00000000010"}
+    end
+
+    before do
+      allow(described_class::Inventory).to receive(:new).with(client).and_return(inventory)
+      allow(inventory).to receive(:fetch_instance_info).with(external_id: external_id).and_return(instance_info)
+    end
+
+    it "invokes Inventory#fetch_instance_info and passes along the return value" do
+      expect(client.fetch_instance_info(external_id: external_id)).to eq instance_info
+      expect(inventory).to have_received(:fetch_instance_info).once
+    end
+  end
+
   describe ".fetch_marc_hash" do
     let(:instance_hrid) { "a12854819" }
 

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -454,4 +454,48 @@ RSpec.describe FolioClient do
       expect(described_class::Holdings).to have_received(:new).with(client, instance_id: instance_id)
     end
   end
+
+  describe ".edit_marc_json" do
+    let(:hrid) { "in00000000067" }
+    let(:mock_marc_json) do
+      {"001" => "foo", "856" => "bar", "245" => "baz"}
+    end
+
+    before do
+      allow(described_class.instance).to receive(:edit_marc_json).and_yield(mock_marc_json)
+    end
+
+    it "invokes instance#edit_marc_json on the caller's block" do # rubocop:disable RSpec/ExampleLength
+      block_ran = false
+      client.edit_marc_json(hrid: hrid) do |marc_json|
+        expect(marc_json).to be mock_marc_json
+        block_ran = true
+      end
+      expect(block_ran).to be true
+      expect(client.instance).to have_received(:edit_marc_json).with(hrid: hrid)
+    end
+  end
+
+  describe "#edit_marc_json" do
+    let(:hrid) { "in00000000067" }
+    let(:records_editor) { instance_double(described_class::RecordsEditor) }
+    let(:mock_marc_json) do
+      {"001" => "foo", "856" => "bar", "245" => "baz"}
+    end
+
+    before do
+      allow(described_class::RecordsEditor).to receive(:new).with(client).and_return(records_editor)
+      allow(records_editor).to receive(:edit_marc_json).and_yield(mock_marc_json)
+    end
+
+    it "invokes RecordsEditor#edit_marc_json on the caller's block" do # rubocop:disable RSpec/ExampleLength
+      block_ran = false
+      client.edit_marc_json(hrid: hrid) do |marc_json|
+        expect(marc_json).to be mock_marc_json
+        block_ran = true
+      end
+      expect(block_ran).to be true
+      expect(records_editor).to have_received(:edit_marc_json).with(hrid: hrid)
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

fixes #29

## How was this change tested? 🤨

unit tests, edits made against folio test instance from laptop dor-services-app rails console (with my local DSA instance pointed at this branch of folio_client)

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

