### PR TITLE
Increase connection timeout and error info

### DIFF
--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -35,6 +35,9 @@ class FolioClient
   # Error raised when the Folio API returns a 422 Unprocessable Entity
   class ValidationError < Error; end
 
+  # Error raised when the Folio API returns a 409 Conflict
+  class ConflictError < Error; end
+
   DEFAULT_HEADERS = {
     accept: "application/json, text/plain",
     content_type: "application/json"
@@ -120,7 +123,8 @@ class FolioClient
   def connection
     @connection ||= Faraday.new(
       url: config.url,
-      headers: DEFAULT_HEADERS.merge(config.okapi_headers || {})
+      headers: DEFAULT_HEADERS.merge(config.okapi_headers || {}),
+      request: {timeout: 120}
     )
   end
 

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -47,15 +47,15 @@ class FolioClient
     # @param url [String] the folio API URL
     # @param login_params [Hash] the folio client login params (username:, password:)
     # @param okapi_headers [Hash] the okapi specific headers to add (X-Okapi-Tenant:, User-Agent:)
-    def configure(url:, login_params:, okapi_headers:)
-      instance.config = OpenStruct.new(url: url, login_params: login_params, okapi_headers: okapi_headers, token: nil)
+    def configure(url:, login_params:, okapi_headers:, timeout: default_timeout)
+      instance.config = OpenStruct.new(url: url, login_params: login_params, okapi_headers: okapi_headers, token: nil, timeout: timeout)
 
       instance.config.token = Authenticator.token(login_params, connection)
 
       self
     end
 
-    delegate :config, :connection, :get, :post, :put, to: :instance
+    delegate :config, :connection, :get, :post, :put, :default_timeout, to: :instance
     delegate :fetch_hrid, :fetch_external_id, :fetch_instance_info, :fetch_marc_hash, :has_instance_status?, :data_import, :edit_marc_json,
       :organizations, :organization_interfaces, :interface_details, to: :instance
   end
@@ -124,7 +124,7 @@ class FolioClient
     @connection ||= Faraday.new(
       url: config.url,
       headers: DEFAULT_HEADERS.merge(config.okapi_headers || {}),
-      request: {timeout: 120}
+      request: {timeout: config.timeout}
     )
   end
 
@@ -195,5 +195,9 @@ class FolioClient
     Organizations
       .new(self)
       .fetch_interface_details(...)
+  end
+
+  def default_timeout
+    120
   end
 end

--- a/lib/folio_client/unexpected_response.rb
+++ b/lib/folio_client/unexpected_response.rb
@@ -12,10 +12,12 @@ class FolioClient
         raise ForbiddenError, "The operation requires privileges which the client does not have: #{response.body}"
       when 404
         raise ResourceNotFound, "Endpoint not found or resource does not exist: #{response.body}"
+      when 409
+        raise ConflictError, "Resource cannot be updated: #{response.body}"
       when 422
-        raise ValidationError, "There was a validation problem with the request: #{response.body} "
+        raise ValidationError, "There was a validation problem with the request: #{response.body}"
       when 500
-        raise ServiceUnavailable, "The remote server returned an internal server error."
+        raise ServiceUnavailable, "The remote server returned an internal server error: #{response.body}"
       else
         raise StandardError, "Unexpected response: #{response.status} #{response.body}"
       end

--- a/spec/folio_client/authenticator_spec.rb
+++ b/spec/folio_client/authenticator_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe FolioClient::Authenticator do
       end
     end
 
+    context "when the service returns a 409 conflict error" do
+      let(:http_status) { 409 }
+      let(:http_body) { "{\"error\" : \"get bent\"}" }
+
+      it "raises a conflict error exception" do
+        expect { authenticator.token }.to raise_error(FolioClient::ConflictError)
+      end
+    end
+
     context "when the truly unexpected happens" do
       let(:http_status) { 666 }
       let(:http_body) { "{\"error\" : \"huh?\"}" }

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe FolioClient do
       expect(client.config.okapi_headers).to eq(okapi_headers)
     end
 
+    it "gets the default timeout value" do
+      expect(client.config.timeout).to eq(120)
+    end
+
     it "stores the fetched token in the config" do
       expect(client.config.token).to eq(token)
     end


### PR DESCRIPTION
## Why was this change made? 🤔
Add info to several errors and adding a 409 error. Bumping the timeout in Faraday request options seemed to greatly reduce the number of timeouts noted in testing quick-marc updates. 

## How was this change tested? 🤨
Unit, testing with DSA QA deploys.

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

