### PR TITLE
List data import job profiles

### DIFF
--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -64,8 +64,8 @@ class FolioClient
 
     delegate :config, :connection, :data_import, :default_timeout, :edit_marc_json,
       :fetch_external_id, :fetch_hrid, :fetch_instance_info, :fetch_marc_hash, :get,
-      :has_instance_status?, :interface_details, :organization_interfaces, :organizations,
-      :post, :put, to: :instance
+      :has_instance_status?, :interface_details, :job_profiles, :organization_interfaces,
+      :organizations, :post, :put, to: :instance
   end
 
   attr_accessor :config
@@ -178,6 +178,13 @@ class FolioClient
     DataImport
       .new(self)
       .import(...)
+  end
+
+  # @ see DataImport#job_profiles
+  def job_profiles(...)
+    DataImport
+      .new(self)
+      .job_profiles(...)
   end
 
   # @see RecordsEditor#edit_marc_json

--- a/lib/folio_client/data_import.rb
+++ b/lib/folio_client/data_import.rb
@@ -7,6 +7,8 @@ require "stringio"
 class FolioClient
   # Imports MARC records into FOLIO
   class DataImport
+    JOB_PROFILE_ATTRIBUTES = %w[id name description dataType].freeze
+
     # @param client [FolioClient] the configured client
     def initialize(client)
       @client = client
@@ -37,6 +39,14 @@ class FolioClient
       )
 
       JobStatus.new(client, job_execution_id: job_execution_id)
+    end
+
+    # @return [Array<Hash<String,String>>] a list of job profile hashes
+    def job_profiles
+      client
+        .get("/data-import-profiles/jobProfiles")
+        .fetch("jobProfiles", [])
+        .map { |profile| profile.slice(*JOB_PROFILE_ATTRIBUTES) }
     end
 
     private

--- a/spec/folio_client/data_import_spec.rb
+++ b/spec/folio_client/data_import_spec.rb
@@ -8,14 +8,6 @@ RSpec.describe FolioClient::DataImport do
   let(:okapi_headers) { {some_bogus_headers: "here"} }
   let(:token) { "a_long_silly_token" }
   let(:client) { FolioClient.configure(**args) }
-  let(:marc) do
-    MARC::Record.new.tap do |record|
-      record << MARC::DataField.new("245", "0", " ", ["a", "Folio 21: a bibliography of the Folio Society 1947-1967"])
-    end
-  end
-  let(:job_profile_id) { "ae0a94d0" }
-  let(:job_profile_name) { "ETDs" }
-  let(:job_execution_id) { "4ba4f4ab" }
 
   before do
     stub_request(:post, "#{url}/authn/login")
@@ -24,6 +16,14 @@ RSpec.describe FolioClient::DataImport do
   end
 
   describe "#import" do
+    let(:marc) do
+      MARC::Record.new.tap do |record|
+        record << MARC::DataField.new("245", "0", " ", ["a", "Folio 21: a bibliography of the Folio Society 1947-1967"])
+      end
+    end
+    let(:job_profile_id) { "ae0a94d0" }
+    let(:job_profile_name) { "ETDs" }
+    let(:job_execution_id) { "4ba4f4ab" }
     let(:upload_definition_request_body) do
       {
         fileDefinitions:
@@ -32,7 +32,6 @@ RSpec.describe FolioClient::DataImport do
         ]
       }
     end
-
     let(:upload_definition_response_body) do
       {
         id: "d39546ed-622b-4e09-92ca-210535ff7ab4",
@@ -82,7 +81,6 @@ RSpec.describe FolioClient::DataImport do
         }
       }
     end
-
     let(:process_request_body) do
       {
         uploadDefinition: upload_file_response_body,
@@ -130,6 +128,40 @@ RSpec.describe FolioClient::DataImport do
 
     it "returns a JobStatus instance" do
       expect(data_import.import(marc: marc, job_profile_id: job_profile_id, job_profile_name: job_profile_name)).to be_instance_of(FolioClient::JobStatus)
+    end
+  end
+
+  describe "#job_profiles" do
+    subject(:profiles) { data_import.job_profiles }
+
+    let(:job_profiles_body) do
+      <<~JOB_PROFILES_JSON
+        {"jobProfiles":[{"id":"6409dcff-71fa-433a-bc6a-e70ad38a9604","name":"quickMARC - Derive a new SRS MARC Bib and Instance","description":"This job profile is used by the quickMARC Derive action to create a new SRS MARC Bib record and corresponding Inventory Instance. It cannot be edited or deleted.","dataType":"MARC","deleted":false,"userInfo":{"firstName":"System","lastName":"System","userName":"System"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2021-01-14T14:00:00.000+00:00","createdByUserId":"00000000-0000-0000-0000-000000000000","updatedDate":"2021-01-14T15:00:00.462+00:00","updatedByUserId":"00000000-0000-0000-0000-000000000000"}},{"id":"6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3","name":"Default - Create SRS MARC Authority","description":"Default job profile for creating MARC authority records. These records are stored in source record storage (SRS). Profile cannot be edited or deleted","dataType":"MARC","tags":{"tagList":[]},"deleted":false,"userInfo":{"firstName":"System","lastName":"System","userName":"System"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2021-03-16T15:00:00.000+00:00","createdByUserId":"00000000-0000-0000-0000-000000000000","updatedDate":"2021-03-16T15:00:00.000+00:00","updatedByUserId":"00000000-0000-0000-0000-000000000000"}},{"id":"80898dee-449f-44dd-9c8e-37d5eb469b1d","name":"Default - Create Holdings and SRS MARC Holdings","description":"Default job profile for creating MARC holdings and corresponding Inventory holdings. Profile cannot be edited or deleted","dataType":"MARC","tags":{"tagList":[]},"deleted":false,"userInfo":{"firstName":"System","lastName":"System","userName":"System"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2021-03-16T15:00:00.000+00:00","createdByUserId":"00000000-0000-0000-0000-000000000000","updatedDate":"2021-03-16T15:00:00.000+00:00","updatedByUserId":"00000000-0000-0000-0000-000000000000"}},{"id":"fa0262c7-5816-48d0-b9b3-7b7a862a5bc7","name":"quickMARC - Create Holdings and SRS MARC Holdings","description":"This job profile is used by the quickMARC to allow a user to create a new SRS MARC holdings record and corresponding Inventory holdings. Profile cannot be edited or deleted","dataType":"MARC","tags":{"tagList":[]},"deleted":false,"userInfo":{"firstName":"System","lastName":"System","userName":"System"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2021-03-16T15:00:00.000+00:00","createdByUserId":"00000000-0000-0000-0000-000000000000","updatedDate":"2021-03-16T15:00:00.000+00:00","updatedByUserId":"00000000-0000-0000-0000-000000000000"}},{"id":"e34d7b92-9b83-11eb-a8b3-0242ac130003","name":"Default - Create instance and SRS MARC Bib","description":"This job profile creates SRS MARC Bib records and corresponding Inventory Instances using the library's default MARC-to-Instance mapping. It can be edited, duplicated, or deleted.","dataType":"MARC","deleted":false,"userInfo":{"firstName":"System","lastName":"System","userName":"System"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2021-04-13T14:00:00.000+00:00","createdByUserId":"00000000-0000-0000-0000-000000000000","updatedDate":"2021-04-13T15:00:00.462+00:00","updatedByUserId":"00000000-0000-0000-0000-000000000000"}},{"id":"d0ebb7b0-2f0f-11eb-adc1-0242ac120002","name":"Inventory Single Record - Default Create Instance","description":"Triggered by an action in Inventory, this job profile imports a single record from an external system, to create an Instance and MARC record","dataType":"MARC","tags":{"tagList":[]},"deleted":false,"userInfo":{"firstName":"System","lastName":"System","userName":"System"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2020-11-23T12:00:00.000+00:00","createdByUserId":"00000000-0000-0000-0000-000000000000","createdByUsername":"System","updatedDate":"2020-11-24T12:00:00.000+00:00","updatedByUserId":"00000000-0000-0000-0000-000000000000","updatedByUsername":"System"}},{"id":"91f9b8d6-d80e-4727-9783-73fb53e3c786","name":"Inventory Single Record - Default Update Instance","description":"Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record","dataType":"MARC","deleted":false,"userInfo":{"firstName":"System","lastName":"System","userName":"System"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2020-11-30T09:07:47.667+00:00","createdByUserId":"6a010e5b-5421-5b1c-9b52-568b37038575","updatedDate":"2020-11-30T09:09:10.382+00:00","updatedByUserId":"6a010e5b-5421-5b1c-9b52-568b37038575"}},{"id":"ae0a94d0-1f8e-4177-bcf9-c3a90e4c9429","name":"ETDs New","description":"Test for ETD new records","dataType":"MARC","deleted":false,"userInfo":{"lastName":"Superuser","userName":"libsys_admin"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2023-03-23T16:16:52.604+00:00","createdByUserId":"3e2ed889-52f2-45ce-8a30-8767266f07d2","updatedDate":"2023-03-23T16:16:52.604+00:00","updatedByUserId":"3e2ed889-52f2-45ce-8a30-8767266f07d2"}},{"id":"7b590640-e924-454f-a4c4-254797c6b94a","name":"SUL load MARC","description":"","dataType":"MARC","deleted":false,"userInfo":{"lastName":"Superuser","userName":"libsys_admin"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2023-03-23T16:16:56.696+00:00","createdByUserId":"3e2ed889-52f2-45ce-8a30-8767266f07d2","updatedDate":"2023-03-23T16:16:56.696+00:00","updatedByUserId":"3e2ed889-52f2-45ce-8a30-8767266f07d2"}},{"id":"2af1026b-1c90-4ebd-8b45-1a1d4b44fb27","name":"Internet","description":"","dataType":"MARC","deleted":false,"userInfo":{"lastName":"Superuser","userName":"libsys_admin"},"parentProfiles":[],"childProfiles":[],"hidden":false,"metadata":{"createdDate":"2023-03-23T16:16:57.195+00:00","createdByUserId":"3e2ed889-52f2-45ce-8a30-8767266f07d2","updatedDate":"2023-03-23T16:16:57.195+00:00","updatedByUserId":"3e2ed889-52f2-45ce-8a30-8767266f07d2"}}],"totalRecords":24}
+      JOB_PROFILES_JSON
+    end
+
+    before do
+      stub_request(:get, "#{url}/data-import-profiles/jobProfiles")
+        .with(
+          headers: {
+            "Content-Type" => "application/json",
+            "X-Okapi-Token" => "a_long_silly_token"
+          }
+        )
+        .to_return(status: 200, body: job_profiles_body, headers: {})
+    end
+
+    it "returns the expected number of profiles" do
+      expect(profiles.count).to eq(10)
+    end
+
+    it "returns the expected fields for profiles" do
+      expect(profiles).to all(have_keys("id", "name", "description", "dataType"))
+    end
+
+    # NOTE: not checking all values; just using dataType as a sample
+    it "returns the expected values for profiles" do
+      expect(profiles.map { |profile| profile["dataType"] }).to all(eq("MARC"))
     end
   end
 end

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -338,6 +338,31 @@ RSpec.describe FolioClient do
     end
   end
 
+  describe ".job_profiles" do
+    before do
+      allow(described_class.instance).to receive(:job_profiles)
+    end
+
+    it "invokes instance#job_profiles" do
+      client.job_profiles
+      expect(client.instance).to have_received(:job_profiles)
+    end
+  end
+
+  describe "#job_profiles" do
+    let(:importer) { instance_double(described_class::DataImport) }
+
+    before do
+      allow(described_class::DataImport).to receive(:new).and_return(importer)
+      allow(importer).to receive(:job_profiles)
+    end
+
+    it "invokes DataImport#job_profiles" do
+      client.job_profiles
+      expect(importer).to have_received(:job_profiles).once
+    end
+  end
+
   describe ".has_instance_status?" do
     let(:hrid) { "a12854819" }
     let(:status_id) { "1a2b3c4d-1234" }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,20 @@ require "byebug"
 require "folio_client"
 require "webmock/rspec"
 
+# Requires supporting ruby files with custom matchers and macros, etc, in
+# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
+# run as spec files by default. This means that files in spec/support that end
+# in _spec.rb will both be required and run as specs, causing the specs to be
+# run twice. It is recommended that you do not name files matching this glob to
+# end with _spec.rb. You can configure this pattern with the --pattern
+# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
+#
+# The following line is provided for convenience purposes. It has the downside
+# of increasing the boot-up time by auto-requiring all files in the support
+# directory. Alternatively, in the individual `*_spec.rb` files, manually
+# require only the support files necessary.
+Dir[Pathname(Dir.pwd).join("spec/support/**/*.rb")].each { |f| require f }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"

--- a/spec/support/have_keys_matcher.rb
+++ b/spec/support/have_keys_matcher.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Check multiple hash keys at once
+RSpec::Matchers.define :have_keys do |*keys|
+  match do |hash|
+    keys.all? { |key| expect(hash).to have_key(key) }
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #62

This commit adds a new API endpoint for returning information about data import job profiles, including the ID, name, description, and data type. Uses a new, custom RSpec matcher to verify multiple hash keys exist in a single check.

This supports work for our current work cycle on the Folio "data loading management" application.

## How was this change tested? 🤨

CI + tested against folio-test
