### PR TITLE
Use the change-manager API to determine file processing has completed

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,15 @@ client.fetch_marc_hash(instance_hrid: "a7927874")
   [{"003"=>"FOLIO"}....]
   }
 
-# Import a MARC record into FOLIO
-data_importer = client.data_import(marc: my_marc, job_profile_id: '4ba4f4ab', job_profile_name: 'ETDs')
+# Import MARC records into FOLIO
+data_importer = client.data_import(records: [marc_record1, marc_record2], job_profile_id: '4ba4f4ab', job_profile_name: 'ETDs')
 # If called too quickly, might get Failure(:not_found)
 data_importer.status
  => Failure(:pending)
 data_importer.wait_until_complete
  => Success()
-data_importer.instance_hrid
- => Success("in00000000010")
+data_importer.instance_hrids
+ => Success(["in00000000010", "in00000000011"])
 
 # Get list of organizations (filtered with an optional query)
 # see https://s3.amazonaws.com/foliodocs/api/mod-organizations/p/organizations.html#organizations_organizations_get

--- a/spec/folio_client/data_import_spec.rb
+++ b/spec/folio_client/data_import_spec.rb
@@ -16,10 +16,13 @@ RSpec.describe FolioClient::DataImport do
   end
 
   describe "#import" do
-    let(:marc) do
-      MARC::Record.new.tap do |record|
-        record << MARC::DataField.new("245", "0", " ", ["a", "Folio 21: a bibliography of the Folio Society 1947-1967"])
-      end
+    let(:marc_file_name) { "2023-03-01T11:17:25-05:00.marc" }
+    let(:records) do
+      [
+        MARC::Record.new.tap do |record|
+          record << MARC::DataField.new("245", "0", " ", ["a", "Folio 21: a bibliography of the Folio Society 1947-1967"])
+        end
+      ]
     end
     let(:job_profile_id) { "ae0a94d0" }
     let(:job_profile_name) { "ETDs" }
@@ -28,7 +31,7 @@ RSpec.describe FolioClient::DataImport do
       {
         fileDefinitions:
         [
-          {name: "2023-03-01T11:17:25-05:00.marc"}
+          {name: marc_file_name}
         ]
       }
     end
@@ -41,7 +44,7 @@ RSpec.describe FolioClient::DataImport do
         fileDefinitions: [
           {
             id: "181f6315-aa98-4b4d-ab1f-3c7f9df524b1",
-            name: "2023-03-01T11:17:25-05:00.marc",
+            name: marc_file_name,
             status: "NEW",
             jobExecutionId: job_execution_id,
             uploadDefinitionId: "d39546ed-622b-4e09-92ca-210535ff7ab4",
@@ -66,7 +69,7 @@ RSpec.describe FolioClient::DataImport do
         fileDefinitions: [
           {
             id: "181f6315-aa98-4b4d-ab1f-3c7f9df524b1",
-            name: "2023-03-01T11:17:25-05:00.marc",
+            name: marc_file_name,
             status: "UPLOADED",
             jobExecutionId: job_execution_id,
             uploadDefinitionId: "d39546ed-622b-4e09-92ca-210535ff7ab4",
@@ -127,7 +130,7 @@ RSpec.describe FolioClient::DataImport do
     end
 
     it "returns a JobStatus instance" do
-      expect(data_import.import(marc: marc, job_profile_id: job_profile_id, job_profile_name: job_profile_name)).to be_instance_of(FolioClient::JobStatus)
+      expect(data_import.import(records: records, job_profile_id: job_profile_id, job_profile_name: job_profile_name)).to be_instance_of(FolioClient::JobStatus)
     end
   end
 

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -307,24 +307,24 @@ RSpec.describe FolioClient do
   describe ".data_import" do
     let(:job_profile_id) { "4ba4f4ab" }
     let(:job_profile_name) { "ETDs" }
-    let(:marc) { instance_double(MARC::Record) }
+    let(:records) { [instance_double(MARC::Record)] }
 
     before do
       allow(described_class.instance).to receive(:data_import)
-        .with(job_profile_id: job_profile_id, job_profile_name: job_profile_name, marc: marc)
+        .with(job_profile_id: job_profile_id, job_profile_name: job_profile_name, records: records)
     end
 
     it "invokes instance#data_import" do
-      client.data_import(job_profile_id: job_profile_id, job_profile_name: job_profile_name, marc: marc)
+      client.data_import(job_profile_id: job_profile_id, job_profile_name: job_profile_name, records: records)
       expect(client.instance).to have_received(:data_import)
-        .with(job_profile_id: job_profile_id, job_profile_name: job_profile_name, marc: marc)
+        .with(job_profile_id: job_profile_id, job_profile_name: job_profile_name, records: records)
     end
   end
 
   describe "#data_import" do
     let(:job_profile_id) { "4ba4f4ab" }
     let(:job_profile_name) { "ETDs" }
-    let(:marc) { instance_double(MARC::Record) }
+    let(:records) { [instance_double(MARC::Record)] }
     let(:importer) { instance_double(described_class::DataImport) }
 
     before do
@@ -333,7 +333,7 @@ RSpec.describe FolioClient do
     end
 
     it "invokes DataImport#import" do
-      client.data_import(job_profile_id: job_profile_id, job_profile_name: job_profile_name, marc: marc)
+      client.data_import(job_profile_id: job_profile_id, job_profile_name: job_profile_name, records: records)
       expect(importer).to have_received(:import).once
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

This commit updates our best understanding of how to navigate the Folio APIs to determine that a `processFiles` request has finished running. Adapted from https://github.com/sul-dlss/libsys-airflow/pull/670

As part of this work, expand data import functionality to be able to handle multiple records.

## How was this change tested? 🤨

CI + run against stage with a test script
