### PR TITLE
[HOLD] Do not authenticate as part of client configuration

### DIFF
--- a/lib/folio_client/organizations.rb
+++ b/lib/folio_client/organizations.rb
@@ -19,7 +19,9 @@ class FolioClient
     def fetch_list(query: nil, limit: 10000, offset: 0, lang: "en")
       params = {limit: limit, offset: offset, lang: lang}
       params[:query] = query if query
-      client.get("/organizations/organizations", params)
+      response = client.connection.get("/organizations/organizations", params, client.http_get_headers)
+      UnexpectedResponse.call(response) unless response.success?
+      JSON.parse(response.body)
     end
 
     # @param query [String] an optional query to limit the number of organization interfaces returned
@@ -29,15 +31,19 @@ class FolioClient
     def fetch_interface_list(query: nil, limit: 10000, offset: 0, lang: "en")
       params = {limit: limit, offset: offset, lang: lang}
       params[:query] = query if query
-      client.get("/organizations-storage/interfaces", params)
+      response = client.connection.get("/organizations-storage/interfaces", params, client.http_get_headers)
+      UnexpectedResponse.call(response) unless response.success?
+      JSON.parse(response.body)
     end
 
     # @param id [String] id for requested storage interface
     # @param lang [String] language code for returned result (defaults to 'en')
     def fetch_interface_details(id:, lang: "en")
-      client.get("/organizations-storage/interfaces/#{id}", {
+      response = client.connection.get("/organizations-storage/interfaces/#{id}", {
         lang: lang
-      })
+      }, client.http_get_headers)
+      UnexpectedResponse.call(response) unless response.success?
+      JSON.parse(response.body)
     end
   end
 end

--- a/lib/folio_client/records_editor.rb
+++ b/lib/folio_client/records_editor.rb
@@ -28,14 +28,19 @@ class FolioClient
       version = instance_info["_version"]
       external_id = instance_info["id"]
 
-      record_json = client.get("/records-editor/records", {externalId: external_id})
+      response = client.connection.get("/records-editor/records", {externalId: external_id}, client.http_get_headers)
+      UnexpectedResponse.call(response) unless response.success?
+      record_json = JSON.parse(response.body)
 
       parsed_record_id = record_json["parsedRecordId"]
+
       record_json["relatedRecordVersion"] = version # setting this field on the JSON we send back is what will allow optimistic locking to catch stale updates
 
       yield record_json
 
-      client.put("/records-editor/records/#{parsed_record_id}", record_json)
+      response = client.connection.put("/records-editor/records/#{parsed_record_id}", record_json, client.http_post_and_put_headers)
+      UnexpectedResponse.call(response) unless response.success?
+      JSON.parse(response.body)
     end
   end
 end

--- a/lib/folio_client/source_storage.rb
+++ b/lib/folio_client/source_storage.rb
@@ -16,7 +16,9 @@ class FolioClient
     # @raise [ResourceNotFound]
     # @raise [MultipleResourcesFound]
     def fetch_marc_hash(instance_hrid:)
-      response_hash = client.get("/source-storage/source-records", {instanceHrid: instance_hrid})
+      response = client.connection.get("/source-storage/source-records", {instanceHrid: instance_hrid}, client.http_get_headers)
+      UnexpectedResponse.call(response) unless response.success?
+      response_hash = JSON.parse(response.body)
 
       record_count = response_hash["totalRecords"]
       raise ResourceNotFound, "No records found for #{instance_hrid}" if record_count.zero?

--- a/lib/folio_client/token_wrapper.rb
+++ b/lib/folio_client/token_wrapper.rb
@@ -4,7 +4,7 @@ class FolioClient
   # Wraps API operations to request new access token if expired
   class TokenWrapper
     def self.refresh(config, connection)
-      yield.tap { |response| UnexpectedResponse.call(response) unless response.success? }
+      yield
     rescue UnauthorizedError
       config.token = Authenticator.token(config.login_params, connection)
       yield

--- a/spec/folio_client/authenticator_spec.rb
+++ b/spec/folio_client/authenticator_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe FolioClient::Authenticator do
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }
-  let(:token) { "a_long_silly_token" }
+  let(:token) { "a temporary dummy token to avoid hitting the API before it is needed" }
   let(:connection) { FolioClient.configure(**args).connection }
   let(:http_status) { 200 }
   let(:http_body) { "{\"okapiToken\" : \"#{token}\"}" }

--- a/spec/folio_client/data_import_spec.rb
+++ b/spec/folio_client/data_import_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe FolioClient::DataImport do
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }
-  let(:token) { "a_long_silly_token" }
+  let(:token) { "a temporary dummy token to avoid hitting the API before it is needed" }
   let(:client) { FolioClient.configure(**args) }
 
   before do
@@ -102,7 +102,7 @@ RSpec.describe FolioClient::DataImport do
           body: upload_definition_request_body.to_json,
           headers: {
             "Content-Type" => "application/json",
-            "X-Okapi-Token" => "a_long_silly_token"
+            "X-Okapi-Token" => token
           }
         ).to_return(status: 200,
           body: upload_definition_response_body.to_json,
@@ -113,7 +113,7 @@ RSpec.describe FolioClient::DataImport do
           body: "00098     2200037   4500245006000000\u001E0 \u001FaFolio 21: a bibliography of the Folio Society 1947-1967\u001E\u001D",
           headers: {
             "Content-Type" => "application/octet-stream",
-            "X-Okapi-Token" => "a_long_silly_token"
+            "X-Okapi-Token" => token
           }
         )
         .to_return(status: 200, body: upload_file_response_body.to_json, headers: {})
@@ -123,7 +123,7 @@ RSpec.describe FolioClient::DataImport do
           body: process_request_body.to_json,
           headers: {
             "Content-Type" => "application/json",
-            "X-Okapi-Token" => "a_long_silly_token"
+            "X-Okapi-Token" => token
           }
         )
         .to_return(status: 204, body: "", headers: {})
@@ -148,7 +148,7 @@ RSpec.describe FolioClient::DataImport do
         .with(
           headers: {
             "Content-Type" => "application/json",
-            "X-Okapi-Token" => "a_long_silly_token"
+            "X-Okapi-Token" => token
           }
         )
         .to_return(status: 200, body: job_profiles_body, headers: {})

--- a/spec/folio_client/inventory_spec.rb
+++ b/spec/folio_client/inventory_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FolioClient::Inventory do
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }
-  let(:token) { "a_long_silly_token" }
+  let(:token) { "a temporary dummy token to avoid hitting the API before it is needed" }
   let(:client) { FolioClient.configure(**args) }
   let(:barcode) { "123456" }
   let(:instance_uuid) { "some_long_uuid_that_is_long" }

--- a/spec/folio_client/job_status_spec.rb
+++ b/spec/folio_client/job_status_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FolioClient::JobStatus do
     )
   end
   let(:job_execution_id) { "4ba4f4ab" }
-  let(:token) { "a_long_silly_token" }
+  let(:token) { "a temporary dummy token to avoid hitting the API before it is needed" }
   let(:url) { "https://folio.example.org" }
 
   before do

--- a/spec/folio_client/organizations_spec.rb
+++ b/spec/folio_client/organizations_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe FolioClient::Organizations do
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }
-  let(:token) { "a_long_silly_token" }
+  let(:token) { "a temporary dummy token to avoid hitting the API before it is needed" }
   let(:client) { FolioClient.configure(**args) }
   let(:id) { "some_long_id_that_is_long" }
   let(:query) { '"active=="true"' }

--- a/spec/folio_client/source_storage_spec.rb
+++ b/spec/folio_client/source_storage_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe FolioClient::SourceStorage do
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }
-  let(:token) { "aLongSTring.eNCodinga.JwTeeeee" }
+  let(:token) { "a temporary dummy token to avoid hitting the API before it is needed" }
   let(:client) { FolioClient.configure(**args) }
   let(:instance_hrid) { "a666" }
-
   let(:post_authn_request_headers) {
     {
       "Accept" => "application/json, text/plain",

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FolioClient do
   let(:url) { "https://folio.example.org" }
   let(:login_params) { {username: "username", password: "password"} }
   let(:okapi_headers) { {some_bogus_headers: "here"} }
-  let(:token) { "a_long_silly_token" }
+  let(:token) { "a temporary dummy token to avoid hitting the API before it is needed" }
 
   before do
     stub_request(:post, "#{url}/authn/login")
@@ -37,7 +37,7 @@ RSpec.describe FolioClient do
       expect(client.config.timeout).to eq(120)
     end
 
-    it "stores the fetched token in the config" do
+    it "stores a dummy token in the config" do
       expect(client.config.token).to eq(token)
     end
   end
@@ -69,7 +69,7 @@ RSpec.describe FolioClient do
               "Accept" => "application/json, text/plain",
               "Content-Type" => "application/json",
               "Some-Bogus-Headers" => "here",
-              "X-Okapi-Token" => "a_long_silly_token"
+              "X-Okapi-Token" => token
             }
           )
           .to_return(status: 200, body: response.to_json, headers: {})
@@ -88,7 +88,7 @@ RSpec.describe FolioClient do
             headers: {
               "Accept" => "application/json, text/plain",
               "Some-Bogus-Headers" => "here",
-              "X-Okapi-Token" => "a_long_silly_token"
+              "X-Okapi-Token" => token
             }
           )
           .to_return(status: 200, body: response.to_json, headers: {})
@@ -108,7 +108,7 @@ RSpec.describe FolioClient do
               "Accept" => "application/json, text/plain",
               "Content-Type" => "text/plain",
               "Some-Bogus-Headers" => "here",
-              "X-Okapi-Token" => "a_long_silly_token"
+              "X-Okapi-Token" => token
             }
           )
           .to_return(status: 200, body: response.to_json, headers: {})
@@ -133,7 +133,7 @@ RSpec.describe FolioClient do
               "Accept" => "application/json, text/plain",
               "Content-Type" => "application/json",
               "Some-Bogus-Headers" => "here",
-              "X-Okapi-Token" => "a_long_silly_token"
+              "X-Okapi-Token" => token
             }
           )
           .to_return(status: 200, body: response.to_json, headers: {})
@@ -152,7 +152,7 @@ RSpec.describe FolioClient do
             headers: {
               "Accept" => "application/json, text/plain",
               "Some-Bogus-Headers" => "here",
-              "X-Okapi-Token" => "a_long_silly_token"
+              "X-Okapi-Token" => token
             }
           )
           .to_return(status: 200, body: response.to_json, headers: {})
@@ -172,7 +172,7 @@ RSpec.describe FolioClient do
               "Accept" => "application/json, text/plain",
               "Content-Type" => "text/plain",
               "Some-Bogus-Headers" => "here",
-              "X-Okapi-Token" => "a_long_silly_token"
+              "X-Okapi-Token" => token
             }
           )
           .to_return(status: 200, body: response.to_json, headers: {})
@@ -472,7 +472,6 @@ RSpec.describe FolioClient do
   context "when token is expired" do
     let(:inventory) { instance_double(FolioClient::Inventory, fetch_hrid: nil) }
     let(:hrid) { "in56789" }
-    let(:expired_token) { "expired_token" }
     let(:new_token) { "new_token" }
     let(:barcode) { "123456" }
     let(:instance_uuid) { "d71e654b-ca5e-44c0-9621-ae86ffd528d3" }
@@ -506,11 +505,10 @@ RSpec.describe FolioClient do
     before do
       stub_request(:post, "#{url}/authn/login")
         .to_return(
-          {status: 200, body: "{\"okapiToken\" : \"#{expired_token}\"}"},
           {status: 200, body: "{\"okapiToken\" : \"#{new_token}\"}"}
         )
       stub_request(:get, "#{url}/search/instances?query=items.barcode==#{barcode}")
-        .with(headers: {"x-okapi-token": expired_token})
+        .with(headers: {"x-okapi-token": token})
         .to_return(
           {status: 401, body: "invalid authN token"}
         )
@@ -527,7 +525,7 @@ RSpec.describe FolioClient do
     it "fetches new token and retries" do
       expect { client.fetch_hrid(barcode: barcode) }
         .to change(client.config, :token)
-        .from(expired_token)
+        .from(token)
         .to(new_token)
     end
   end


### PR DESCRIPTION
# Why was this change made?

Related to sul-dlss/globus_client#107

I could not wrap my brain about getting this to work without refactoring the client to be more like GlobusClient. The main difference was that FolioClient prior to this commit had functions re-using the same HTTP methods to do heavy lifting, which was making it difficult for me to reason about what was happening and why. This is the second time I've struggled to make sense of it (see: https://github.com/sul-dlss/folio_client/pull/27#discussion_r1122428121), so I went all in on the refactor which brings parity to our client gems. I see the main trade-off as now we have more code duplication and less swirly dependencies?

For the initial token, use a dummy value to avoid hitting any APIs during configuration, allowing the TokenWrapper to handle auto-magic token refreshing. Why not immediately get a valid token? Our apps commonly invoke client .configure methods in the initializer in all application environments, even those that are never expected to connect to production APIs, such as local development machines.

NOTE: nil and blank string cannot be used as dummy values here as they lead to a malformed request to be sent, which triggers an exception not rescued by TokenWrapper

# How was this change tested?

CI, ran a local `api_test.rb` file which I have stashed but that we probably don't want to live in GitHub
