### PR TITLE
instead of eagerly fetching a token on client initialization, lazily wait for the first request to fail, and use the token refresh mechanism

### DIFF
--- a/spec/folio_client/data_import_spec.rb
+++ b/spec/folio_client/data_import_spec.rb
@@ -8,10 +8,27 @@ RSpec.describe FolioClient::DataImport do
   let(:okapi_headers) { {some_bogus_headers: "here"} }
   let(:token) { "a_long_silly_token" }
   let(:client) { FolioClient.configure(**args) }
+  let(:search_instance_response) {
+    {"totalRecords" => 1,
+     "instances" => [
+       {"id" => "some_long_uuid_that_is_long",
+        "title" => "Training videos",
+        "contributors" => [{"name" => "Person"}],
+        "isBoundWith" => false,
+        "holdings" => []}
+     ]}
+  }
 
   before do
+    # the client is initialized with a fake token (see comment in FolioClient.configure for why).  this
+    # simulates the initial obtainment of a valid token after FolioClient makes the very first post-initialization request.
+    stub_request(:get, "#{url}/search/instances?query=hrid==in808")
+      .to_return({status: 401}, {status: 200, body: search_instance_response.to_json})
     stub_request(:post, "#{url}/authn/login")
       .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+
+    client.fetch_external_id(hrid: "in808")
+
     allow(DateTime).to receive(:now).and_return(DateTime.parse("2023-03-01T11:17:25-05:00"))
   end
 

--- a/spec/folio_client/job_status_spec.rb
+++ b/spec/folio_client/job_status_spec.rb
@@ -14,10 +14,27 @@ RSpec.describe FolioClient::JobStatus do
   let(:job_execution_id) { "4ba4f4ab" }
   let(:token) { "a_long_silly_token" }
   let(:url) { "https://folio.example.org" }
+  let(:search_instance_response) {
+    {"totalRecords" => 1,
+     "instances" => [
+       {"id" => "some_long_uuid_that_is_long",
+        "title" => "Training videos",
+        "contributors" => [{"name" => "Person"}],
+        "isBoundWith" => false,
+        "holdings" => []}
+     ]}
+  }
 
   before do
+    # the client is initialized with a fake token (see comment in FolioClient.configure for why).  this
+    # simulates the initial obtainment of a valid token after FolioClient makes the very first post-initialization request.
+    stub_request(:get, "#{url}/search/instances?query=hrid==in808")
+      .to_return({status: 401}, {status: 200, body: search_instance_response.to_json})
     stub_request(:post, "#{url}/authn/login")
       .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+
+    client.fetch_external_id(hrid: "in808")
+
     allow(DateTime).to receive(:now).and_return(DateTime.parse("2023-03-01T11:17:25-05:00"))
   end
 


### PR DESCRIPTION
this is a recreation of @mjgiarlo's https://github.com/sul-dlss/folio_client/pull/77 minus the refactoring and `TokenWrapper.refresh` behavioral change.  thus, it preserves the current behavior of only re-executing the one failed request after re-authenticating, instead of it and all prior API calls made in the given high-level `FolioClient` method (e.g. `FolioClient.fetch_hrid`).

we'll iterate in subsequent commits on making the token refresh mechanism easier to understand at a glance.  but this fixes the issue of e.g. bringing up a rails console in a dev env with no credentials configured, and a possible honeybadger alert being logged.

## Why was this change made? 🤔

to avoid annoying alerts when running rails console or bringing up the app for consumers of this gem in environments where we don't even intend to set up valid credentials, because we don't expect to need to connect to a real folio instance.  e.g. our laptop dev environments.

## How was this change tested? 🤨

unit tests.

can also run through integration tests using e.g. a branch of DSA with its `Gemfile` tweaked to point to this branch?

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

