### PR TITLE
Add endpoint for retrieving MARC XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and the created tag, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+## Integration Testing
+
+To test that the gem works against the Folio APIs, run `api_test.rb` via:
+
+```shell
+# NOTE: This is bash syntax, YMMV
+$ export OKAPI_PASSWORD=$(vault kv get --field=content puppet/application/folio/stage/app_sdr_password)
+$ export OKAPI_TENANT=sul
+$ export OKAPI_USER=app_sdr
+$ export OKAPI_URL=https://okapi-stage.stanford.edu
+# NOTE: The args below are a list of MARC files
+$ bundle exec ruby ./api_test.rb /path/to/marc/files/test.mrc /another/marc/file/at/foobar.marc
+```
+
+Inspect the output and make sure there are no errors.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/sul-dlss/folio_client.

--- a/api_test.rb
+++ b/api_test.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+require "bundler/setup"
+require "folio_client"
+
+marc_files = *ARGV
+
+client =
+  FolioClient.configure(
+    url: ENV["OKAPI_URL"],
+    login_params: {
+      username: ENV["OKAPI_USER"],
+      password: ENV["OKAPI_PASSWORD"]
+    },
+    okapi_headers: {
+      "X-Okapi-Tenant": ENV["OKAPI_TENANT"],
+      "User-Agent": "folio_client gem (testing)"
+    }
+  )
+
+pp(client.fetch_marc_hash(instance_hrid: "a666"))
+
+puts client.fetch_marc_xml(instance_hrid: "a666")
+puts client.fetch_marc_xml(barcode: "20503330279")
+
+records = marc_files.flat_map do |marc_file_path|
+  MARC::Reader.new(marc_file_path).to_a
+end
+
+data_importer =
+  client.data_import(
+    records: records,
+    job_profile_id: "e34d7b92-9b83-11eb-a8b3-0242ac130003",
+    job_profile_name: "Default - Create instance and SRS MARC Bib"
+  )
+
+puts data_importer.wait_until_complete
+puts data_importer.instance_hrids

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -3,8 +3,9 @@
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/object/blank"
 require "faraday"
-require "singleton"
+require "marc"
 require "ostruct"
+require "singleton"
 require "zeitwerk"
 
 # Load the gem's internal dependencies: use Zeitwerk instead of needing to manually require classes
@@ -72,10 +73,10 @@ class FolioClient
 
     delegate :config, :connection, :data_import, :default_timeout,
       :edit_marc_json, :fetch_external_id, :fetch_hrid, :fetch_instance_info,
-      :fetch_marc_hash, :get, :has_instance_status?, :http_get_headers,
-      :http_post_and_put_headers, :interface_details, :job_profiles,
-      :organization_interfaces, :organizations, :post, :put, to: :instance
-  end
+      :fetch_marc_hash, :fetch_marc_xml, :get, :has_instance_status?,
+      :http_get_headers, :http_post_and_put_headers, :interface_details,
+      :job_profiles, :organization_interfaces, :organizations, :post, :put, to:
+      :instance end
 
   attr_accessor :config
 
@@ -173,6 +174,13 @@ class FolioClient
     SourceStorage
       .new(self)
       .fetch_marc_hash(...)
+  end
+
+  # @see SourceStorage#fetch_marc_xml
+  def fetch_marc_xml(...)
+    SourceStorage
+      .new(self)
+      .fetch_marc_xml(...)
   end
 
   # @see Inventory#has_instance_status?

--- a/lib/folio_client/data_import.rb
+++ b/lib/folio_client/data_import.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "date"
-require "marc"
 require "stringio"
 
 class FolioClient

--- a/spec/folio_client/source_storage_spec.rb
+++ b/spec/folio_client/source_storage_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe FolioClient::SourceStorage do
   let(:token) { "aLongSTring.eNCodinga.JwTeeeee" }
   let(:client) { FolioClient.configure(**args) }
   let(:instance_hrid) { "a666" }
-
-  let(:search_instance_response) {
+  let(:search_instance_response) do
     {"totalRecords" => 1,
      "instances" => [
        {"id" => "some_long_uuid_that_is_long",
@@ -20,16 +19,101 @@ RSpec.describe FolioClient::SourceStorage do
         "isBoundWith" => false,
         "holdings" => []}
      ]}
-  }
-
-  let(:post_authn_request_headers) {
+  end
+  let(:post_authn_request_headers) do
     {
       "Accept" => "application/json, text/plain",
       "Content-Type" => "application/json",
       "Some-Bogus-Headers" => "here",
       "X-Okapi-Token" => token
     }
-  }
+  end
+  let(:source_storage_response) do
+    {"sourceRecords" =>
+     [{"recordId" => "992460aa-bfe6-50ff-93f6-65c6aa786a43",
+       "snapshotId" => "5ae00995-bcb3-4fdc-8519-75c1357c44c4",
+       "recordType" => "MARC_BIB",
+       "parsedRecord" =>
+       {"id" => "992460aa-bfe6-50ff-93f6-65c6aa786a43",
+        "content" =>
+        {"fields" =>
+         [
+           {"001" => "a666"},
+           {"003" => "SIRSI"},
+           {"005" => "19900820141050.0"},
+           {"008" => "750409s1961||||enk           ||| | eng  "},
+           {"010" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "   62039356\\\\72b2"}]}},
+           {"040" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"d" => "OrLoB"}]}},
+           {"050" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "M231.B66 Bb maj. 1961"}]}},
+           {"100" =>
+            {"ind1" => "1", "ind2" => " ", "subfields" => [{"a" => "Boccherini, Luigi,"}, {"d" => "1743-1805."}]}},
+           {"240" =>
+            {"ind1" => "1",
+             "ind2" => "0",
+             "subfields" => [{"a" => "Sonatas,"}, {"m" => "cello, continuo,"}, {"r" => "B♭ major"}]}},
+           {"245" =>
+            {"ind1" => " ",
+             "ind2" => "0",
+             "subfields" =>
+             [
+               {"a" => "Sonata no. 7, in B flat, for violoncello and piano."},
+               {"c" =>
+               "Edited with realization of the basso continuo by Fritz Spiegl and Walter Bergamnn. Violoncello part edited by Joan Dickson."}
+             ]}},
+           {"260" =>
+            {"ind1" => " ",
+             "ind2" => " ",
+             "subfields" =>
+             [{"a" => "London, Schott; New York, Associated Music Publishers"}, {"c" => "[c1961]"}]}},
+           {"300" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "score (20 p.) & part."}, {"c" => "29cm."}]}},
+           {"490" => {"ind1" => "1", "ind2" => " ", "subfields" => [{"a" => "Edition [Schott]  10731"}]}},
+           {"500" =>
+            {"ind1" => " ",
+             "ind2" => " ",
+             "subfields" =>
+             [{"a" =>
+               "Edited from a recently discovered ms. Closely parallels Gruetzmacher's free arrangement of the Violoncello concerto, G. 482."}]}},
+           {"596" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "31"}]}},
+           {"650" => {"ind1" => " ", "ind2" => "0", "subfields" => [{"a" => "Sonatas (Cello and harpsichord)"}]}},
+           {"700" =>
+            {"ind1" => "1",
+             "ind2" => "2",
+             "subfields" =>
+             [
+               {"a" => "Boccherini, Luigi,"},
+               {"d" => "1743-1805."},
+               {"t" => "Concertos,"},
+               {"m" => "cello, orchestra,"},
+               {"n" => "G. 482,"},
+               {"r" => "B♭ major"},
+               {"o" => "arranged."}
+             ]}},
+           {"830" => {"ind1" => " ", "ind2" => "0", "subfields" => [{"a" => "Edition Schott"}, {"v" => "10731"}]}},
+           {"998" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "SCORE"}]}},
+           {"035" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "(OCoLC-M)17708345"}]}},
+           {"035" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "(OCoLC-I)268876650"}]}},
+           {"918" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "666"}]}},
+           {"035" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "AAA0675"}]}},
+           {"999" =>
+            {"ind1" => "f",
+             "ind2" => "f",
+             "subfields" =>
+             [
+               {"i" => "696ef04d-1902-5a70-aebf-98d287bce1a1"},
+               {"s" => "992460aa-bfe6-50ff-93f6-65c6aa786a43"}
+             ]}}
+         ],
+         "leader" => "01185ccm a2200301   4500"}},
+       "deleted" => false,
+       "externalIdsHolder" => {"instanceId" => "696ef04d-1902-5a70-aebf-98d287bce1a1", "instanceHrid" => "a666"},
+       "additionalInfo" => {"suppressDiscovery" => false},
+       "metadata" =>
+       {"createdDate" => "2023-02-11T03:54:43.938+00:00",
+        "createdByUserId" => "3e2ed889-52f2-45ce-8a30-8767266f07d2",
+        "updatedDate" => "2023-02-11T03:54:44.574+00:00",
+        "updatedByUserId" => "3e2ed889-52f2-45ce-8a30-8767266f07d2"}}],
+     "totalRecords" => 1}
+  end
 
   before do
     # the client is initialized with a fake token (see comment in FolioClient.configure for why).  this
@@ -46,16 +130,41 @@ RSpec.describe FolioClient::SourceStorage do
       .to_return(status: 200, body: source_storage_response.to_json)
   end
 
-  context "when exactly 1 instance record is found" do
-    let(:source_storage_response) {
-      {"sourceRecords" =>
-        [{"recordId" => "992460aa-bfe6-50ff-93f6-65c6aa786a43",
-          "snapshotId" => "5ae00995-bcb3-4fdc-8519-75c1357c44c4",
-          "recordType" => "MARC_BIB",
-          "parsedRecord" =>
-           {"id" => "992460aa-bfe6-50ff-93f6-65c6aa786a43",
-            "content" =>
-             {"fields" =>
+  describe "#fetch_marc_hash" do
+    context "when exactly 1 instance record is found (happy path)" do
+      it "returns the parsed JSON as a hash for the one record that was found" do
+        result = source_storage.fetch_marc_hash(instance_hrid: instance_hrid)
+        expect(result["fields"].select { |field_hash| field_hash.key?("001") }.map(&:values)).to eq([["a666"]])
+        expect(result["fields"].select { |field_hash| field_hash.key?("008") }.map(&:values)).to eq([["750409s1961||||enk           ||| | eng  "]])
+        expect(result["fields"].select { |field_hash| field_hash.key?("050") }.map(&:values)).to eq([[{"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "M231.B66 Bb maj. 1961"}]}]])
+      end
+    end
+
+    context "when no instance records are found" do
+      let(:source_storage_response) do
+        {"sourceRecords" => [], "totalRecords" => 0}
+      end
+
+      it "raises a NotFound exception" do
+        expect { source_storage.fetch_marc_hash(instance_hrid: instance_hrid) }.to raise_error(FolioClient::ResourceNotFound, "No records found for #{instance_hrid}")
+      end
+    end
+
+    context "when multiple instance records are found" do
+      # based on a real Folio response, but omits some returned fields, and duplicates and lightly
+      # modifies the one record from the real response. that makes this spec file slightly less gigantic,
+      # and still simulates the relevant part of the response structure.
+      let(:source_storage_response) {
+        {"sourceRecords" =>
+         [
+           {
+             "recordId" => "992460aa-bfe6-50ff-93f6-65c6aa786a43",
+             "snapshotId" => "5ae00995-bcb3-4fdc-8519-75c1357c44c4",
+             "recordType" => "MARC_BIB",
+             "parsedRecord" =>
+             {"id" => "992460aa-bfe6-50ff-93f6-65c6aa786a43",
+              "content" =>
+              {"fields" =>
                [{"001" => "a666"},
                  {"003" => "SIRSI"},
                  {"005" => "19900820141050.0"},
@@ -64,161 +173,111 @@ RSpec.describe FolioClient::SourceStorage do
                  {"040" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"d" => "OrLoB"}]}},
                  {"050" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "M231.B66 Bb maj. 1961"}]}},
                  {"100" =>
-                   {"ind1" => "1", "ind2" => " ", "subfields" => [{"a" => "Boccherini, Luigi,"}, {"d" => "1743-1805."}]}},
+                  {"ind1" => "1", "ind2" => " ", "subfields" => [{"a" => "Boccherini, Luigi,"}, {"d" => "1743-1805."}]}},
                  {"240" =>
-                   {"ind1" => "1",
-                    "ind2" => "0",
-                    "subfields" => [{"a" => "Sonatas,"}, {"m" => "cello, continuo,"}, {"r" => "B♭ major"}]}},
-                 {"245" =>
-                   {"ind1" => " ",
-                    "ind2" => "0",
-                    "subfields" =>
-                     [{"a" => "Sonata no. 7, in B flat, for violoncello and piano."},
-                       {"c" =>
-                         "Edited with realization of the basso continuo by Fritz Spiegl and Walter Bergamnn. Violoncello part edited by Joan Dickson."}]}},
-                 {"260" =>
-                   {"ind1" => " ",
-                    "ind2" => " ",
-                    "subfields" =>
-                     [{"a" => "London, Schott; New York, Associated Music Publishers"}, {"c" => "[c1961]"}]}},
-                 {"300" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "score (20 p.) & part."}, {"c" => "29cm."}]}},
-                 {"490" => {"ind1" => "1", "ind2" => " ", "subfields" => [{"a" => "Edition [Schott]  10731"}]}},
-                 {"500" =>
-                   {"ind1" => " ",
-                    "ind2" => " ",
-                    "subfields" =>
-                     [{"a" =>
-                        "Edited from a recently discovered ms. Closely parallels Gruetzmacher's free arrangement of the Violoncello concerto, G. 482."}]}},
-                 {"596" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "31"}]}},
-                 {"650" => {"ind1" => " ", "ind2" => "0", "subfields" => [{"a" => "Sonatas (Cello and harpsichord)"}]}},
-                 {"700" =>
-                   {"ind1" => "1",
-                    "ind2" => "2",
-                    "subfields" =>
-                     [{"a" => "Boccherini, Luigi,"},
-                       {"d" => "1743-1805."},
-                       {"t" => "Concertos,"},
-                       {"m" => "cello, orchestra,"},
-                       {"n" => "G. 482,"},
-                       {"r" => "B♭ major"},
-                       {"o" => "arranged."}]}},
-                 {"830" => {"ind1" => " ", "ind2" => "0", "subfields" => [{"a" => "Edition Schott"}, {"v" => "10731"}]}},
-                 {"998" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "SCORE"}]}},
-                 {"035" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "(OCoLC-M)17708345"}]}},
-                 {"035" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "(OCoLC-I)268876650"}]}},
-                 {"918" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "666"}]}},
-                 {"035" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "AAA0675"}]}},
-                 {"999" =>
-                   {"ind1" => "f",
-                    "ind2" => "f",
-                    "subfields" =>
-                     [{"i" => "696ef04d-1902-5a70-aebf-98d287bce1a1"},
-                       {"s" => "992460aa-bfe6-50ff-93f6-65c6aa786a43"}]}}],
-              "leader" => "01185ccm a2200301   4500"}},
-          "deleted" => false,
-          "externalIdsHolder" => {"instanceId" => "696ef04d-1902-5a70-aebf-98d287bce1a1", "instanceHrid" => "a666"},
-          "additionalInfo" => {"suppressDiscovery" => false},
-          "metadata" =>
-           {"createdDate" => "2023-02-11T03:54:43.938+00:00",
-            "createdByUserId" => "3e2ed889-52f2-45ce-8a30-8767266f07d2",
-            "updatedDate" => "2023-02-11T03:54:44.574+00:00",
-            "updatedByUserId" => "3e2ed889-52f2-45ce-8a30-8767266f07d2"}}],
-       "totalRecords" => 1}
-    }
-
-    it "returns the parsed JSON as a hash for the one record that was found" do
-      result = source_storage.fetch_marc_hash(instance_hrid: instance_hrid)
-      expect(result["fields"].select { |field_hash| field_hash.key?("001") }.map(&:values)).to eq([["a666"]])
-      expect(result["fields"].select { |field_hash| field_hash.key?("008") }.map(&:values)).to eq([["750409s1961||||enk           ||| | eng  "]])
-      expect(result["fields"].select { |field_hash| field_hash.key?("050") }.map(&:values)).to eq([[{"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "M231.B66 Bb maj. 1961"}]}]])
-    end
-  end
-
-  context "when no instance records are found" do
-    let(:source_storage_response) {
-      {"sourceRecords" => [], "totalRecords" => 0}
-    }
-
-    it "raises a NotFound exception" do
-      expect { source_storage.fetch_marc_hash(instance_hrid: instance_hrid) }.to raise_error(FolioClient::ResourceNotFound, "No records found for #{instance_hrid}")
-    end
-  end
-
-  context "when multiple instance records are found" do
-    # based on a real Folio response, but omits some returned fields, and duplicates and lightly
-    # modifies the one record from the real response. that makes this spec file slightly less gigantic,
-    # and still simulates the relevant part of the response structure.
-    let(:source_storage_response) {
-      {"sourceRecords" =>
-        [
-          {
-            "recordId" => "992460aa-bfe6-50ff-93f6-65c6aa786a43",
-            "snapshotId" => "5ae00995-bcb3-4fdc-8519-75c1357c44c4",
-            "recordType" => "MARC_BIB",
-            "parsedRecord" =>
-             {"id" => "992460aa-bfe6-50ff-93f6-65c6aa786a43",
-              "content" =>
-               {"fields" =>
-                 [{"001" => "a666"},
-                   {"003" => "SIRSI"},
-                   {"005" => "19900820141050.0"},
-                   {"008" => "750409s1961||||enk           ||| | eng  "},
-                   {"010" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "   62039356\\\\72b2"}]}},
-                   {"040" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"d" => "OrLoB"}]}},
-                   {"050" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "M231.B66 Bb maj. 1961"}]}},
-                   {"100" =>
-                     {"ind1" => "1", "ind2" => " ", "subfields" => [{"a" => "Boccherini, Luigi,"}, {"d" => "1743-1805."}]}},
-                   {"240" =>
-                     {"ind1" => "1",
-                      "ind2" => "0",
-                      "subfields" => [{"a" => "Sonatas,"}, {"m" => "cello, continuo,"}, {"r" => "B♭ major"}]}}],
-                "leader" => "01185ccm a2200301   4500"}},
-            "deleted" => false,
-            "externalIdsHolder" => {"instanceId" => "696ef04d-1902-5a70-aebf-98d287bce1a1", "instanceHrid" => "a666"},
-            "additionalInfo" => {"suppressDiscovery" => false},
-            "metadata" =>
+                  {"ind1" => "1",
+                   "ind2" => "0",
+                   "subfields" => [{"a" => "Sonatas,"}, {"m" => "cello, continuo,"}, {"r" => "B♭ major"}]}}],
+               "leader" => "01185ccm a2200301   4500"}},
+             "deleted" => false,
+             "externalIdsHolder" => {"instanceId" => "696ef04d-1902-5a70-aebf-98d287bce1a1", "instanceHrid" => "a666"},
+             "additionalInfo" => {"suppressDiscovery" => false},
+             "metadata" =>
              {"createdDate" => "2023-02-11T03:54:43.938+00:00",
               "createdByUserId" => "3e2ed889-52f2-45ce-8a30-8767266f07d2",
               "updatedDate" => "2023-02-11T03:54:44.574+00:00",
               "updatedByUserId" => "3e2ed889-52f2-45ce-8a30-8767266f07d2"}
-          },
-          {
-            "recordId" => "992460aa-bfe6-50ff-93f6-65c6aa786a54",
-            "snapshotId" => "5ae00995-bcb3-4fdc-8519-75c1357c44d5",
-            "recordType" => "MARC_BIB",
-            "parsedRecord" =>
+           },
+           {
+             "recordId" => "992460aa-bfe6-50ff-93f6-65c6aa786a54",
+             "snapshotId" => "5ae00995-bcb3-4fdc-8519-75c1357c44d5",
+             "recordType" => "MARC_BIB",
+             "parsedRecord" =>
              {"id" => "992460aa-bfe6-50ff-93f6-65c6aa786a54",
               "content" =>
-               {"fields" =>
-                 [{"001" => "a666"},
-                   {"003" => "SIRSI"},
-                   {"005" => "19900820141050.0"},
-                   {"008" => "750409s1961||||enk           ||| | eng  "},
-                   {"010" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "   62039356\\\\72b2"}]}},
-                   {"040" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"d" => "OrLoB"}]}},
-                   {"050" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "M231.B66 Bb maj. 1961"}]}},
-                   {"100" =>
-                     {"ind1" => "1", "ind2" => " ", "subfields" => [{"a" => "Boccherini, Luigi,"}, {"d" => "1743-1805."}]}},
-                   {"240" =>
-                     {"ind1" => "1",
-                      "ind2" => "0",
-                      "subfields" => [{"a" => "Sonatas,"}, {"m" => "cello, continuo,"}, {"r" => "B♭ major"}]}}],
-                "leader" => "01185ccm a2200301   4500"}},
-            "deleted" => false,
-            "externalIdsHolder" => {"instanceId" => "696ef04d-1902-5a70-aebf-98d287bce1b2", "instanceHrid" => "a666"},
-            "additionalInfo" => {"suppressDiscovery" => false},
-            "metadata" =>
+              {"fields" =>
+               [{"001" => "a666"},
+                 {"003" => "SIRSI"},
+                 {"005" => "19900820141050.0"},
+                 {"008" => "750409s1961||||enk           ||| | eng  "},
+                 {"010" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "   62039356\\\\72b2"}]}},
+                 {"040" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"d" => "OrLoB"}]}},
+                 {"050" => {"ind1" => " ", "ind2" => " ", "subfields" => [{"a" => "M231.B66 Bb maj. 1961"}]}},
+                 {"100" =>
+                  {"ind1" => "1", "ind2" => " ", "subfields" => [{"a" => "Boccherini, Luigi,"}, {"d" => "1743-1805."}]}},
+                 {"240" =>
+                  {"ind1" => "1",
+                   "ind2" => "0",
+                   "subfields" => [{"a" => "Sonatas,"}, {"m" => "cello, continuo,"}, {"r" => "B♭ major"}]}}],
+               "leader" => "01185ccm a2200301   4500"}},
+             "deleted" => false,
+             "externalIdsHolder" => {"instanceId" => "696ef04d-1902-5a70-aebf-98d287bce1b2", "instanceHrid" => "a666"},
+             "additionalInfo" => {"suppressDiscovery" => false},
+             "metadata" =>
              {"createdDate" => "2023-02-12T03:54:43.938+00:00",
               "createdByUserId" => "3e2ed889-52f2-45ce-8a30-8767266f07d2",
               "updatedDate" => "2023-02-12T03:54:44.574+00:00",
               "updatedByUserId" => "3e2ed889-52f2-45ce-8a30-8767266f07d2"}
-          }
-        ],
-       "totalRecords" => 2}
-    }
+           }
+         ],
+         "totalRecords" => 2}
+      }
 
-    it "raises a MultipleRecordsForIdentifier exception" do
-      expect { source_storage.fetch_marc_hash(instance_hrid: instance_hrid) }.to raise_error(FolioClient::MultipleResourcesFound, "Expected 1 record for #{instance_hrid}, but found 2")
+      it "raises a MultipleRecordsForIdentifier exception" do
+        expect { source_storage.fetch_marc_hash(instance_hrid: instance_hrid) }.to raise_error(FolioClient::MultipleResourcesFound, "Expected 1 record for #{instance_hrid}, but found 2")
+      end
+    end
+  end
+
+  describe "#fetch_marc_xml" do
+    context "with neither a barcode nor an instance HRID" do
+      it "raises ArgumentError" do
+        expect { source_storage.fetch_marc_xml(barcode: nil, instance_hrid: nil) }
+          .to raise_error(ArgumentError, /Either a barcode or a Folio instance HRID must be provided/)
+      end
+    end
+
+    context "with a barcode that is not found" do
+      let(:source_storage_response) do
+        {"sourceRecords" => [], "totalRecords" => 0}
+      end
+
+      before do
+        allow(source_storage.client).to receive(:fetch_hrid).and_return(nil)
+      end
+
+      it "raises ResourceNotFound" do
+        expect { source_storage.fetch_marc_xml(barcode: "12345678", instance_hrid: nil) }
+          .to raise_error(FolioClient::ResourceNotFound, /Catalog record not found/)
+      end
+    end
+
+    context "with an instance HRID that is not found" do
+      let(:source_storage_response) do
+        {"sourceRecords" => [], "totalRecords" => 0}
+      end
+
+      it "raises ResourceNotFound" do
+        expect { source_storage.fetch_marc_xml(barcode: nil, instance_hrid: instance_hrid) }
+          .to raise_error(FolioClient::ResourceNotFound, /No records found for #{instance_hrid}/)
+      end
+    end
+
+    context "with an instance HRID that is found, whether given a barcode or not (happy path)" do
+      it "uses the HRID and returns MARC XML" do
+        expected = <<~MARCXML.chomp
+          <record xmlns='http://www.loc.gov/MARC21/slim'><leader>01185ccm a2200301   4500</leader><controlfield tag='005'>19900820141050.0</controlfield><controlfield tag='008'>750409s1961||||enk           ||| | eng  </controlfield><datafield ind1=' ' ind2=' ' tag='010'><subfield code='a'>   62039356\\\\72b2</subfield></datafield><datafield ind1=' ' ind2=' ' tag='040'><subfield code='d'>OrLoB</subfield></datafield><datafield ind1=' ' ind2=' ' tag='050'><subfield code='a'>M231.B66 Bb maj. 1961</subfield></datafield><datafield ind1='1' ind2=' ' tag='100'><subfield code='a'>Boccherini, Luigi,</subfield><subfield code='d'>1743-1805.</subfield></datafield><datafield ind1='1' ind2='0' tag='240'><subfield code='a'>Sonatas,</subfield><subfield code='m'>cello, continuo,</subfield><subfield code='r'>B♭ major</subfield></datafield><datafield ind1=' ' ind2='0' tag='245'><subfield code='a'>Sonata no. 7, in B flat, for violoncello and piano.</subfield><subfield code='c'>Edited with realization of the basso continuo by Fritz Spiegl and Walter Bergamnn. Violoncello part edited by Joan Dickson.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='260'><subfield code='a'>London, Schott; New York, Associated Music Publishers</subfield><subfield code='c'>[c1961]</subfield></datafield><datafield ind1=' ' ind2=' ' tag='300'><subfield code='a'>score (20 p.) &amp; part.</subfield><subfield code='c'>29cm.</subfield></datafield><datafield ind1='1' ind2=' ' tag='490'><subfield code='a'>Edition [Schott]  10731</subfield></datafield><datafield ind1=' ' ind2=' ' tag='500'><subfield code='a'>Edited from a recently discovered ms. Closely parallels Gruetzmacher&apos;s free arrangement of the Violoncello concerto, G. 482.</subfield></datafield><datafield ind1=' ' ind2=' ' tag='596'><subfield code='a'>31</subfield></datafield><datafield ind1=' ' ind2='0' tag='650'><subfield code='a'>Sonatas (Cello and harpsichord)</subfield></datafield><datafield ind1='1' ind2='2' tag='700'><subfield code='a'>Boccherini, Luigi,</subfield><subfield code='d'>1743-1805.</subfield><subfield code='t'>Concertos,</subfield><subfield code='m'>cello, orchestra,</subfield><subfield code='n'>G. 482,</subfield><subfield code='r'>B♭ major</subfield><subfield code='o'>arranged.</subfield></datafield><datafield ind1=' ' ind2='0' tag='830'><subfield code='a'>Edition Schott</subfield><subfield code='v'>10731</subfield></datafield><datafield ind1=' ' ind2=' ' tag='998'><subfield code='a'>SCORE</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(OCoLC-M)17708345</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>(OCoLC-I)268876650</subfield></datafield><datafield ind1=' ' ind2=' ' tag='918'><subfield code='a'>666</subfield></datafield><datafield ind1=' ' ind2=' ' tag='035'><subfield code='a'>AAA0675</subfield></datafield><datafield ind1='f' ind2='f' tag='999'><subfield code='i'>696ef04d-1902-5a70-aebf-98d287bce1a1</subfield><subfield code='s'>992460aa-bfe6-50ff-93f6-65c6aa786a43</subfield></datafield><controlfield tag='001'>a666</controlfield><controlfield tag='003'>FOLIO</controlfield></record>
+        MARCXML
+        expect(source_storage.fetch_marc_xml(barcode: nil, instance_hrid: instance_hrid)).to eq(expected)
+      end
+
+      it "ensures returned MARC XML has expected 001 field" do
+        expect(source_storage.fetch_marc_xml(barcode: nil, instance_hrid: instance_hrid)).to match("<controlfield tag='001'>a666</controlfield>")
+      end
+
+      it "ensures returned MARC XML has expected 003 field" do
+        expect(source_storage.fetch_marc_xml(barcode: nil, instance_hrid: instance_hrid)).to match("<controlfield tag='003'>FOLIO</controlfield>")
+      end
     end
   end
 end

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -324,6 +324,34 @@ RSpec.describe FolioClient do
     end
   end
 
+  describe ".fetch_marc_xml" do
+    let(:instance_hrid) { "a12854819" }
+
+    before do
+      allow(described_class.instance).to receive(:fetch_marc_xml).with(instance_hrid: instance_hrid)
+    end
+
+    it "invokes instance#fetch_marc_xml" do
+      client.fetch_marc_xml(instance_hrid: instance_hrid)
+      expect(client.instance).to have_received(:fetch_marc_xml).with(instance_hrid: instance_hrid)
+    end
+  end
+
+  describe "#fetch_marc_xml" do
+    let(:instance_hrid) { "123456" }
+    let(:source_storage) { instance_double(described_class::SourceStorage) }
+
+    before do
+      allow(described_class::SourceStorage).to receive(:new).and_return(source_storage)
+      allow(source_storage).to receive(:fetch_marc_xml)
+    end
+
+    it "invokes SourceStorage#fetch_marc_xml" do
+      client.fetch_marc_xml(instance_hrid: instance_hrid)
+      expect(source_storage).to have_received(:fetch_marc_xml).once
+    end
+  end
+
   describe ".data_import" do
     let(:job_profile_id) { "4ba4f4ab" }
     let(:job_profile_name) { "ETDs" }


### PR DESCRIPTION
# Why was this change made?

Fixes sul-dlss/dor-services-app#4476

* Add endpoint for retrieving MARC XML
* Add an integration-testing script (per `GlobusClient` approach)

# How was this change tested?

- [x] CI
- [x] `./api_test.rb`
- [x] [Argo](https://github.com/sul-dlss/argo/pull/4197) stage
- [x] [GBooks](https://github.com/sul-dlss/google-books/pull/969) QA

