### PR TITLE
add users query endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,14 +126,44 @@ client.interface_details(id: 'c6f7470e-6229-45ce-b3f9-32006e9affcf')
 
 # Get list of users (filtered with an optional query)
 # see https://s3.amazonaws.com/foliodocs/api/mod-users/r/users.html#users_get
-client.users(query: 'username=="a*"')
-=> {"users"=>[....
+client.users(query: 'username=="test*"')
+=> {"users"=>
+  [{"username"=>"testing",
+    "id"=>"bbbadd51-c2f1-4107-a54d-52b39087725c",
+    "externalSystemId"=>"00324439",
+    "barcode"=>"2559202566",
+    "active"=>false,
+    "departments"=>[],
+    "proxyFor"=>[],
+    "personal"=>
+     {"lastName"=>"Testing",
+      "firstName"=>"Test",
+      "email"=>"foliotesting@lists.stanford.edu",
+      "addresses"=>
+       [{"countryId"=>"US",
+         "addressLine1"=>"13 Fake St",
+         "city"=>"Palo Alto",
+         "region"=>"California",
+         "postalCode"=>"94301",
+         "addressTypeId"=>"93d3d88d-499b-45d0-9bc7-ac73c3a19880",
+         "primaryAddress"=>true}]},
+    "createdDate"=>"2023-10-01T08:50:37.203+00:00",
+    "updatedDate"=>"2023-10-01T08:50:37.203+00:00",
+    "metadata"=>
+     {"createdDate"=>"2023-09-02T02:51:43.448+00:00",
+      "createdByUserId"=>"58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+      "updatedDate"=>"2023-10-01T08:50:37.196+00:00",
+      "updatedByUserId"=>"58d0aaf6-dcda-4d5e-92da-012e6b7dd766"},
+    "customFields"=>{"affiliation"=>"affiliate:sponsored"}}],
+ "totalRecords"=>1,
+ "resultInfo"=>{"totalRecords"=>1, "facets"=>[], "diagnostics"=>[]}}
 
 # Get specific user info
 # see https://s3.amazonaws.com/foliodocs/api/mod-users/r/users.html#users_get
-client.user_details(id: 'g07a11f2-47a6-471d-8c80-94d2bb1456fd')
-=> {"username"=>"somebody",
-    "id"=>"g07a11f2-47a6-471d-8c80-94d2bb1456fd", ....
+client.user_details(id: 'bbbadd51-c2f1-4107-a54d-52b39087725c')
+=> {"username"=>"testing",
+    "id"=>"bbbadd51-c2f1-4107-a54d-52b39087725c",
+    "externalSystemId"=>"00324439", ... # same response as above, but for single user
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -123,6 +123,17 @@ client.interface_details(id: 'c6f7470e-6229-45ce-b3f9-32006e9affcf')
     "createdByUserId"=>"38524916-598d-4edf-a2ef-04bba7e78ad6",
     "updatedDate"=>"2023-02-16T22:27:51.515+00:00",
     "updatedByUserId"=>"38524916-598d-4edf-a2ef-04bba7e78ad6"}}
+
+# Get list of users (filtered with an optional query)
+# see https://s3.amazonaws.com/foliodocs/api/mod-users/r/users.html#users_get
+client.users(query: 'username=="a*"')
+=> {"users"=>[....
+
+# Get specific user info
+# see https://s3.amazonaws.com/foliodocs/api/mod-users/r/users.html#users_get
+client.user_details(id: 'g07a11f2-47a6-471d-8c80-94d2bb1456fd')
+=> {"username"=>"somebody",
+    "id"=>"g07a11f2-47a6-471d-8c80-94d2bb1456fd", ....
 ```
 
 ## Development

--- a/api_test.rb
+++ b/api_test.rb
@@ -23,6 +23,8 @@ pp(client.fetch_marc_hash(instance_hrid: "a666"))
 puts client.fetch_marc_xml(instance_hrid: "a666")
 puts client.fetch_marc_xml(barcode: "20503330279")
 
+puts client.users(query: 'username=="pet*"')
+
 records = marc_files.flat_map do |marc_file_path|
   MARC::Reader.new(marc_file_path).to_a
 end

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -75,7 +75,8 @@ class FolioClient
       :edit_marc_json, :fetch_external_id, :fetch_hrid, :fetch_instance_info,
       :fetch_marc_hash, :fetch_marc_xml, :get, :has_instance_status?,
       :http_get_headers, :http_post_and_put_headers, :interface_details,
-      :job_profiles, :organization_interfaces, :organizations, :post, :put, to:
+      :job_profiles, :organization_interfaces, :organizations, :users, :user_details,
+      :post, :put, to:
       :instance end
 
   attr_accessor :config
@@ -230,6 +231,20 @@ class FolioClient
     Organizations
       .new(self)
       .fetch_interface_details(...)
+  end
+
+  # @see Users#fetch_list
+  def users(...)
+    Users
+      .new(self)
+      .fetch_list(...)
+  end
+
+  # @see Users#fetch_user_details
+  def user_details(...)
+    Users
+      .new(self)
+      .fetch_user_details(...)
   end
 
   def default_timeout

--- a/lib/folio_client/users.rb
+++ b/lib/folio_client/users.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class FolioClient
+  # Query user records in Folio; see
+  # https://s3.amazonaws.com/foliodocs/api/mod-users/r/users.html
+  class Users
+    attr_accessor :client
+
+    # @param client [FolioClient] the configured client
+    def initialize(client)
+      @client = client
+    end
+
+    # @param query [String] an optional query to limit the number of users returned
+    # @param limit [Integer] the number of results to return (defaults to 10,000)
+    # @param offset [Integer] the offset for results returned (defaults to 0)
+    # @param lang [String] language code for returned results (defaults to 'en')
+    def fetch_list(query: nil, limit: 10000, offset: 0, lang: "en")
+      params = {limit: limit, offset: offset, lang: lang}
+      params[:query] = query if query
+      client.get("/users", params)
+    end
+
+    # @param id [String] id for requested user
+    # @param lang [String] language code for returned results (defaults to 'en')
+    def fetch_user_details(id:, lang: "en")
+      client.get("/users/#{id}", {
+        lang: lang
+      })
+    end
+  end
+end

--- a/spec/folio_client/organizations_spec.rb
+++ b/spec/folio_client/organizations_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe FolioClient::Organizations do
           "updatedByUserId" => "38524916-598d-4edf-a2ef-04bba7e78ad6"}}
     }
 
-    it "returns the organization list" do
+    it "returns the organization interface details" do
       expect(organizations.fetch_interface_details(id: id)).to eq(organization_interface_detail_response)
     end
   end

--- a/spec/folio_client/users_spec.rb
+++ b/spec/folio_client/users_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+RSpec.describe FolioClient::Users do
+  subject(:users) do
+    described_class.new(client)
+  end
+
+  let(:args) { {url: url, login_params: login_params, okapi_headers: okapi_headers} }
+  let(:url) { "https://folio.example.org" }
+  let(:login_params) { {username: "username", password: "password"} }
+  let(:okapi_headers) { {some_bogus_headers: "here"} }
+  let(:token) { "a_long_silly_token" }
+  let(:client) { FolioClient.configure(**args) }
+  let(:id) { "some_long_id_that_is_long" }
+  let(:query) { '"active=="true"' }
+
+  let(:users_response) {
+    {"users" =>
+    [{"username" => "user",
+      "id" => "6cf89272-3d9f-43f1-af36-33e2c9a0516b",
+      "externalSystemId" => "05733590",
+      "barcode" => "2558668146",
+      "active" => true,
+      "patronGroup" => "503281cd-6c26-400f-b620-14c08943697c",
+      "departments" => ["e85216c6-b39e-477e-a094-de10b941837d"],
+      "proxyFor" => [],
+      "personal" =>
+       {"lastName" => "Last",
+        "firstName" => "First",
+        "middleName" => "Middle",
+        "email" => "foliotesting@lists.stanford.edu",
+        "phone" => "(508) 564-0051",
+        "addresses" =>
+         [{"countryId" => "US",
+           "addressLine1" => "123 Test St",
+           "city" => "Palo Alto",
+           "region" => "California",
+           "postalCode" => "94035",
+           "addressTypeId" => "93d3588d-499b-45d0-9bc7-ac73c3a19880",
+           "primaryAddress" => true},
+           {"countryId" => "US",
+            "addressLine1" => "473 Via Ortega,",
+            "city" => "Stanford",
+            "region" => "California",
+            "postalCode" => "94305",
+            "addressTypeId" => "1c4b215f-f669-4e9b-afcd-ebc0e273a34e",
+            "primaryAddress" => false}],
+        "preferredContactTypeId" => "002"},
+      "enrollmentDate" => "2023-09-01T00:00:00.000+00:00",
+      "createdDate" => "2023-10-05T12:30:06.244+00:00",
+      "updatedDate" => "2023-10-05T12:30:06.244+00:00",
+      "metadata" =>
+       {"createdDate" => "2023-08-10T23:34:05.812+00:00",
+        "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+        "updatedDate" => "2023-10-05T12:30:06.238+00:00",
+        "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"},
+      "customFields" => {"mobileid" => "0515252", "affiliation" => "faculty", "proximitychipid" => "0493670", "department" => "Oceans"}}],
+     "totalRecords" => 1,
+     "resultInfo" => {"totalRecords" => 1, "facets" => [], "diagnostics" => []}}
+  }
+
+  before do
+    stub_request(:post, "#{url}/authn/login")
+      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+  end
+
+  context "when looking up a list of users" do
+    context "when a query is specified" do
+      before do
+        stub_request(:get, "#{url}/users?lang=en&limit=10000&offset=0&query=#{query}")
+          .to_return(status: 200, body: users_response.to_json)
+      end
+
+      it "returns the user list" do
+        expect(users.fetch_list(query: query)).to eq(users_response)
+      end
+    end
+
+    context "when a query is not specified" do
+      before do
+        stub_request(:get, "#{url}/users?lang=en&limit=10000&offset=0")
+          .to_return(status: 200, body: users_response.to_json)
+      end
+
+      it "returns the user list" do
+        expect(users.fetch_list).to eq(users_response)
+      end
+    end
+  end
+
+  context "when looking up details of a specific user" do
+    before do
+      stub_request(:get, "#{url}/users/#{id}?lang=en")
+        .to_return(status: 200, body: user_detail_response.to_json)
+    end
+
+    let(:user_detail_response) {
+      {"username" => "abcdef",
+       "id" => "f07a11f5-47a6-471d-8c80-94d2bb1456fd",
+       "externalSystemId" => "19608544",
+       "active" => false,
+       "departments" => ["e8h216c6-b39e-477e-a094-de10b941837d"],
+       "proxyFor" => [],
+       "personal" => {"lastName" => "Testing", "firstName" => "Last", "middleName" => "V", "addresses" => [], "preferredContactTypeId" => "002"},
+       "createdDate" => "2023-10-07T09:14:19.481+00:00",
+       "updatedDate" => "2023-10-07T09:14:19.481+00:00",
+       "metadata" =>
+       {"createdDate" => "2023-09-07T09:02:30.936+00:00",
+        "createdByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+        "updatedDate" => "2023-10-07T09:14:19.478+00:00",
+        "updatedByUserId" => "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"},
+       "customFields" => {"affiliation" => "affiliate:sponsored"}}
+    }
+
+    it "returns the user details" do
+      expect(users.fetch_user_details(id: id)).to eq(user_detail_response)
+    end
+  end
+end

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -516,6 +516,56 @@ RSpec.describe FolioClient do
     end
   end
 
+  describe ".users" do
+    before do
+      allow(described_class.instance).to receive(:users)
+    end
+
+    it "invokes instance#users" do
+      client.users
+      expect(client.instance).to have_received(:users)
+    end
+  end
+
+  describe "#users" do
+    let(:users) { instance_double(described_class::Users) }
+
+    before do
+      allow(described_class::Users).to receive(:new).and_return(users)
+      allow(users).to receive(:fetch_list)
+    end
+
+    it "invokes Users#fetch_list" do
+      client.public_send(:users)
+      expect(users).to have_received(:fetch_list).once
+    end
+  end
+
+  describe ".user_details" do
+    before do
+      allow(described_class.instance).to receive(:user_details).with(id: "something")
+    end
+
+    it "invokes instance#user_details" do
+      client.user_details(id: "something")
+      expect(client.instance).to have_received(:user_details).with(id: "something")
+    end
+  end
+
+  describe "#user_details" do
+    let(:users) { instance_double(described_class::Users) }
+
+    before do
+      allow(described_class::Users).to receive(:new).and_return(users)
+      allow(users).to receive(:fetch_user_details).with(id: "something")
+    end
+
+    it "invokes Users#fetch_user_details" do
+      client.public_send(:user_details, id: "something")
+      expect(users).to have_received(:fetch_user_details).with(id: "something").once
+    end
+  end
+
   # Tests that we request a new token and then retry the same HTTP call, if the HTTP call
   # returns an unauthorized error
   context "when token is expired" do


### PR DESCRIPTION
## Why was this change made? 🤔

Add a new endpoint to query Folio users and get specific details about a user.  This will be used by https://github.com/sul-dlss/rialto-orgs to get Primary Department affiliation information, which Folio already pulls from the People API and stores.


## How was this change tested? 🤨

New specs
bin/console hitting okapi-stage

