### PR TITLE
Setting configurable higher maximum number of job status checks

### DIFF
--- a/spec/folio_client/job_status_spec.rb
+++ b/spec/folio_client/job_status_spec.rb
@@ -135,8 +135,8 @@ RSpec.describe FolioClient::JobStatus do
       end
 
       it "raises ResourceNotFound" do
-        expect { job_status.wait_until_complete(wait_secs: 0.1) }.to raise_error(FolioClient::ResourceNotFound)
-        expect(job_status).to have_received(:status).exactly(4).times
+        expect { job_status.wait_until_complete(wait_secs: 0.1, max_checks: 3) }.to raise_error(FolioClient::ResourceNotFound)
+        expect(job_status).to have_received(:status).exactly(5).times
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔
Refs https://github.com/sul-dlss/hydra_etd/issues/1573. We have seen data import jobs for ETD stub records take longer to have a job status available than our current code allows. This adds a setting for the status check retries and doesn't raise a NotFoundError unless


## How was this change tested? 🤨
Unit, ran `api_test.rb`  and used with hydra_etd in stage when running the etd_creation integration test. 


