### PR TITLE
Get token from cookie when using /login-with-expiry in Poppy

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       activesupport (>= 4.2, < 8)
       dry-monads
       faraday
+      faraday-cookie_jar
       marc
       zeitwerk
 
@@ -33,6 +34,7 @@ GEM
       rexml
     diff-lcs (1.5.0)
     docile (1.4.0)
+    domain_name (0.6.20231109)
     drb (2.2.0)
       ruby2_keywords
     dry-core (1.0.1)
@@ -46,8 +48,13 @@ GEM
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
+    faraday-cookie_jar (0.0.7)
+      faraday (>= 0.8.0)
+      http-cookie (~> 1.0.0)
     faraday-net_http (3.0.2)
     hashdiff (1.1.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.7.1)

--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ require 'folio_client'
 client = FolioClient.configure(
     url: Settings.okapi.url,
     login_params: Settings.okapi.login_params,
-    okapi_headers: Settings.okapi.headers
+    okapi_headers: Settings.okapi.headers,
+    legacy_auth: true # consumers should leave set to true (default) until /login-with-expiry endpoint enabled in Poppy
 )
 ```
 
 The client is smart enough to automatically request a new token if it detects the one it is using has expired. If for some reason, you want to immediately request a new token, you can do this:
 
 ```ruby
-client.config.token = FolioClient::Authenticator.token(client.config.login_params, client.connection)
+client.config.token = FolioClient::Authenticator.token(client.config.login_params, client.connection, client.config.legacy_auth, client.cookie_jar)
 ```
 
 ## API Coverage

--- a/folio_client.gemspec
+++ b/folio_client.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '>= 4.2', '< 8'
   spec.add_dependency 'dry-monads'
   spec.add_dependency 'faraday'
+  spec.add_dependency 'faraday-cookie_jar'
   spec.add_dependency 'marc'
   spec.add_dependency 'zeitwerk'
 

--- a/lib/folio_client/authenticator.rb
+++ b/lib/folio_client/authenticator.rb
@@ -3,24 +3,42 @@
 class FolioClient
   # Fetch a token from the Folio API using login_params
   class Authenticator
-    def self.token(login_params, connection)
-      new(login_params, connection).token
+    def self.token(login_params, connection, legacy_auth, cookie_jar)
+      new(login_params, connection, legacy_auth, cookie_jar).token
     end
 
-    def initialize(login_params, connection)
+    def initialize(login_params, connection, legacy_auth, cookie_jar)
       @login_params = login_params
       @connection = connection
+      @legacy_auth = legacy_auth
+      @cookie_jar = cookie_jar
     end
 
     # Request an access_token
+    # rubocop:disable Metrics/AbcSize
     def token
-      response = connection.post('/authn/login', login_params.to_json)
+      response = connection.post(login_endpoint, login_params.to_json)
 
       UnexpectedResponse.call(response) unless response.success?
 
-      JSON.parse(response.body)['okapiToken']
+      # remove legacy_auth once new tokens enabled on Poppy
+      if legacy_auth
+        JSON.parse(response.body)['okapiToken']
+      else
+        access_cookies = cookie_jar.cookies.select { |cookie| cookie.name == 'folioAccessToken' }
+        access_cookies[0].value
+      end
     end
+    # rubocop:enable Metrics/AbcSize
 
-    attr_reader :login_params, :connection
+    attr_reader :login_params, :connection, :legacy_auth, :cookie_jar
+
+    private
+
+    def login_endpoint
+      return '/authn/login-with-expiry' unless legacy_auth
+
+      '/authn/login'
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
Resolves #92 to implement new process for getting an access token.  

Currently, the token is in the body of the response from the `/authn/login` endpoint. From Poppy onwards the token will be obtained from a `/authn/login-with-expiry` endpoint and will be in a cookie. See the heading "A guide for non-module clients such as scripts or other integrations" on the [Folio Wiki](https://wiki.folio.org/pages/viewpage.action?pageId=96414255). 

How the token is sent to FOLIO in a request isn't changing. If an expired access token is sent in a request, FOLIO will return a 403 rather than a 401 as it does in Nolana/Orchid. 

If we try to use the `login-with-expiry` endpoint on Nolana, FOLIO returns a 404. The EBSCO FOLIO client sends everything to that endpoint and if it gets a 404, it then tries the `login` endpoint. I thought we might want more control over which endpoint we're sending requests to, especially since the docs say that both endpoints are supported in Poppy and Quesnalia (legacy tokens not removed until Ramsons). This has the downside that we are changing the `FolioClient.configure` method signature and would want to eventually update that to remove the `legacy_auth` param with that is no longer relevant (once we've been on Poppy in production for a bit?). 

Will follow up with:
* shared_configs updates for DSA, Argo, and Google Books
* Update those consumers to pass in a legacy_auth param (rather than rely on default)
* ticket updating the legacy_auth param when we go live with Poppy

## How was this change tested? 🤨
Unit. Tested that the changes do not break current usage by using `api_test.rb`  locally and running the `sdr_deposit_spec.rb` integration test and `item_creation_with_folio_hrid_spec.rb` when using this folio_client version on DSA and Argo QA.

I haven't been able to test this on a live Poppy instance, so that would be good to do as soon as a Poppy dev/test instance is available (Libsys estimates in mid-January). 
