### PR TITLE
Prefer exposing an interface for token refresh over leaking implementation details

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ client = FolioClient.configure(
 The client is smart enough to automatically request a new token if it detects the one it is using has expired. If for some reason, you want to immediately request a new token, you can do this:
 
 ```ruby
-client.config.token = FolioClient::Authenticator.token
+client.force_token_refresh! # or `FolioClient.force_token_refresh!` as they are identical
 ```
 
 ## API Coverage

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -78,11 +78,12 @@ class FolioClient
     end
 
     delegate :config, :connection, :cookie_jar, :data_import, :default_timeout,
-             :edit_marc_json, :fetch_external_id, :fetch_hrid, :fetch_instance_info,
-             :fetch_marc_hash, :fetch_marc_xml, :get, :has_instance_status?,
+             :edit_marc_json, :fetch_external_id, :fetch_hrid,
+             :fetch_instance_info, :fetch_marc_hash, :fetch_marc_xml,
+             :force_token_refresh!, :get, :has_instance_status?,
              :http_get_headers, :http_post_and_put_headers, :interface_details,
-             :job_profiles, :organization_interfaces, :organizations, :users, :user_details,
-             :post, :put, to: :instance
+             :job_profiles, :organization_interfaces, :organizations, :users,
+             :user_details, :post, :put, to: :instance
   end
 
   attr_accessor :config
@@ -268,6 +269,10 @@ class FolioClient
     120
   end
 
+  def force_token_refresh!
+    config.token = Authenticator.token
+  end
+
   private
 
   # Wraps API operations to request new access token if expired.
@@ -287,8 +292,7 @@ class FolioClient
 
     # if unauthorized, token has likely expired. try to get a new token and then retry the same request(s).
     if response.status == 401 || response.status == 403
-
-      config.token = Authenticator.token
+      force_token_refresh!
       response = yield
     end
 

--- a/spec/folio_client_spec.rb
+++ b/spec/folio_client_spec.rb
@@ -62,6 +62,22 @@ RSpec.describe FolioClient do
     end
   end
 
+  describe '#force_token_refresh!' do
+    let(:refreshed_token) { 'another dummy token value' }
+
+    before do
+      stub_request(:post, "#{url}/authn/login")
+        .to_return(status: 200, body: "{\"okapiToken\" : \"#{refreshed_token}\"}")
+    end
+
+    it 'forces a token refresh' do
+      expect { client.force_token_refresh! }
+        .to change(client.config, :token)
+        .from(token)
+        .to(refreshed_token)
+    end
+  end
+
   describe '#get' do
     let(:path) { 'some_path' }
     let(:response) { { some: 'response' }.to_json }


### PR DESCRIPTION
# Why was this change made?

This commit adds a new method to the client singleton (and the containing `FolioClient` class) that provides consumers with an API for forcing token refreshes. This prevents encouraging consumers to delve into client implementation details.

# How was this change tested?

CI + API test run
