### PR TITLE
Update quick-marc actionType for Poppy

### DIFF
--- a/lib/folio_client/records_editor.rb
+++ b/lib/folio_client/records_editor.rb
@@ -28,6 +28,7 @@ class FolioClient
       parsed_record_id = record_json['parsedRecordId']
       # setting this field on the JSON we send back is what will allow optimistic locking to catch stale updates
       record_json['relatedRecordVersion'] = version
+      record_json['_actionType'] = 'edit'
 
       yield record_json
 

--- a/spec/folio_client/records_editor_spec.rb
+++ b/spec/folio_client/records_editor_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe FolioClient::RecordsEditor do
   let(:hrid) { 'in00000000067' }
   let(:external_id) { '5108040a-65bc-40ed-bd50-265958301ce4' }
   let(:mock_response_json) do
-    { 'parsedRecordId' => '1ab23862-46db-4da9-af5b-633adbf5f90f',
+    { '_actionType' => 'view',
+      'parsedRecordId' => '1ab23862-46db-4da9-af5b-633adbf5f90f',
       'parsedRecordDtoId' => '1281ae0b-548b-49e3-b740-050f28e6d57f',
       'suppressDiscovery' => false,
       'marcFormat' => 'BIBLIOGRAPHIC',
@@ -113,7 +114,8 @@ RSpec.describe FolioClient::RecordsEditor do
     end
     expect(client).to have_received(:put).with(
       "/records-editor/records/#{mock_response_json['parsedRecordId']}",
-      hash_including({ 'parsedRecordId' => '1ab23862-46db-4da9-af5b-633adbf5f90f',
+      hash_including({ '_actionType' => 'edit',
+                       'parsedRecordId' => '1ab23862-46db-4da9-af5b-633adbf5f90f',
                        'parsedRecordDtoId' => '1281ae0b-548b-49e3-b740-050f28e6d57f',
                        'relatedRecordVersion' => 1,
                        'externalId' => '5108040a-65bc-40ed-bd50-265958301ce4',


### PR DESCRIPTION
## Why was this change made? 🤔
When sending the Poppy version of FOLIO updates to the MARC 856 tag when releasing/unreleasing, we need to send the expected `_actionType` in the MARC JSON. This is because of breaking changes in the mod-quick-marc module. (More info: https://github.com/folio-org/mod-quick-marc/commit/2ba7b8931b55a284aebbc3951c2d5a87001700e3)

## How was this change tested? 🤨
Released an item to FOLIO stage on Poppy. Still need to test on Nolana, to make sure this doesn't cause any problem with the current version of mod-quick-marc. Will do this by deploying DSA prod using the `folio_client` branch and unreleasing a test record identified by Andrew. 

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

