### PR TITLE
Remove legacy_auth option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ require 'folio_client'
 # this will configure the client and request an access token
 client = FolioClient.configure(
            url: 'https://okapi-dev.stanford.edu',
-           login_params: { username: 'xxx', password: 'yyy', legacy_auth: false },
+           login_params: { username: 'xxx', password: 'yyy' },
            okapi_headers: { 'X-Okapi-Tenant': 'sul', 'User-Agent': 'FolioApiClient' }
          )
 
@@ -44,7 +44,6 @@ client = FolioClient.configure(
     url: Settings.okapi.url,
     login_params: Settings.okapi.login_params,
     okapi_headers: Settings.okapi.headers,
-    legacy_auth: false # was true pre-Poppy release
 )
 ```
 

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -50,9 +50,8 @@ class FolioClient
     # @param url [String] the folio API URL
     # @param login_params [Hash] the folio client login params (username:, password:)
     # @param okapi_headers [Hash] the okapi specific headers to add (X-Okapi-Tenant:, User-Agent:)
-    # @param legacy_auth [Boolean] true to use legacy /login rather than Poppy /login-with-expiry endpoint
     # @return [FolioClient] the configured Singleton class
-    def configure(url:, login_params:, okapi_headers:, timeout: default_timeout, legacy_auth: true)
+    def configure(url:, login_params:, okapi_headers:, timeout: default_timeout, **)
       # rubocop:disable Style/OpenStructUse
       instance.config = OpenStruct.new(
         # For the initial token, use a dummy value to avoid hitting any APIs
@@ -69,8 +68,7 @@ class FolioClient
         url: url,
         login_params: login_params,
         okapi_headers: okapi_headers,
-        timeout: timeout,
-        legacy_auth: legacy_auth # default true until we have new token endpoint enabled in Poppy
+        timeout: timeout
       )
       # rubocop:enable Style/OpenStructUse
 

--- a/lib/folio_client/authenticator.rb
+++ b/lib/folio_client/authenticator.rb
@@ -8,29 +8,22 @@ class FolioClient
     end
 
     # Request an access_token
-    def token # rubocop:disable Metrics/AbcSize
+    def token
       response = FolioClient.connection.post(login_endpoint, FolioClient.config.login_params.to_json)
 
       UnexpectedResponse.call(response) unless response.success?
 
-      # remove legacy_auth once new tokens enabled on Poppy
-      if FolioClient.config.legacy_auth
-        JSON.parse(response.body)['okapiToken']
-      else
-        access_cookie = FolioClient.cookie_jar.cookies.find { |cookie| cookie.name == 'folioAccessToken' }
+      access_cookie = FolioClient.cookie_jar.cookies.find { |cookie| cookie.name == 'folioAccessToken' }
 
-        raise StandardError, "Problem with folioAccessToken cookie: #{response.headers}, #{response.body}" unless access_cookie
+      raise StandardError, "Problem with folioAccessToken cookie: #{response.headers}, #{response.body}" unless access_cookie
 
-        access_cookie.value
-      end
+      access_cookie.value
     end
 
     private
 
     def login_endpoint
-      return '/authn/login-with-expiry' unless FolioClient.config.legacy_auth
-
-      '/authn/login'
+      '/authn/login-with-expiry'
     end
   end
 end

--- a/spec/folio_client/data_import_spec.rb
+++ b/spec/folio_client/data_import_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe FolioClient::DataImport do
   let(:login_params) { { username: 'username', password: 'password' } }
   let(:okapi_headers) { { some_bogus_headers: 'here' } }
   let(:token) { 'a_long_silly_token' }
+  let(:cookie_headers) do
+    { 'Set-Cookie': "folioAccessToken=#{token}; Expires=Fri, 22 Sep 2050 14:30:10 GMT; Path=/; Secure; HTTPOnly; SameSite=None" }
+  end
   let(:search_instance_response) do
     { 'totalRecords' => 1,
       'instances' => [
@@ -26,9 +29,8 @@ RSpec.describe FolioClient::DataImport do
     # simulates the initial obtainment of a valid token after FolioClient makes the very first post-initialization request.
     stub_request(:get, "#{url}/search/instances?query=hrid==in808")
       .to_return({ status: 401 }, { status: 200, body: search_instance_response.to_json })
-    stub_request(:post, "#{url}/authn/login")
-      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
-
+    stub_request(:post, "#{url}/authn/login-with-expiry")
+      .to_return(status: 200, headers: cookie_headers)
     client.fetch_external_id(hrid: 'in808')
 
     allow(DateTime).to receive(:now).and_return(DateTime.parse('2023-03-01T11:17:25-05:00'))

--- a/spec/folio_client/inventory_spec.rb
+++ b/spec/folio_client/inventory_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe FolioClient::Inventory do
   let(:login_params) { { username: 'username', password: 'password' } }
   let(:okapi_headers) { { some_bogus_headers: 'here' } }
   let(:token) { 'a_long_silly_token' }
+  let(:cookie_headers) do
+    { 'Set-Cookie': "folioAccessToken=#{token}; Expires=Fri, 22 Sep 2050 14:30:10 GMT; Path=/; Secure; HTTPOnly; SameSite=None" }
+  end
   let(:client) { FolioClient.instance }
   let(:barcode) { '123456' }
   let(:instance_uuid) { 'some_long_uuid_that_is_long' }
@@ -16,8 +19,8 @@ RSpec.describe FolioClient::Inventory do
   before do
     FolioClient.configure(**args)
 
-    stub_request(:post, "#{url}/authn/login")
-      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+    stub_request(:post, "#{url}/authn/login-with-expiry")
+      .to_return(status: 200, headers: cookie_headers)
   end
 
   context 'when looking up a barcode' do

--- a/spec/folio_client/job_status_spec.rb
+++ b/spec/folio_client/job_status_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe FolioClient::JobStatus do
   end
   let(:job_execution_id) { '4ba4f4ab' }
   let(:token) { 'a_long_silly_token' }
+  let(:cookie_headers) do
+    { 'Set-Cookie': "folioAccessToken=#{token}; Expires=Fri, 22 Sep 2050 14:30:10 GMT; Path=/; Secure; HTTPOnly; SameSite=None" }
+  end
   let(:url) { 'https://folio.example.org' }
   let(:search_instance_response) do
     { 'totalRecords' => 1,
@@ -30,8 +33,8 @@ RSpec.describe FolioClient::JobStatus do
     # simulates the initial obtainment of a valid token after FolioClient makes the very first post-initialization request.
     stub_request(:get, "#{url}/search/instances?query=hrid==in808")
       .to_return({ status: 401 }, { status: 200, body: search_instance_response.to_json })
-    stub_request(:post, "#{url}/authn/login")
-      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+    stub_request(:post, "#{url}/authn/login-with-expiry")
+      .to_return(status: 200, headers: cookie_headers)
 
     client.fetch_external_id(hrid: 'in808')
 

--- a/spec/folio_client/organizations_spec.rb
+++ b/spec/folio_client/organizations_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe FolioClient::Organizations do
   let(:login_params) { { username: 'username', password: 'password' } }
   let(:okapi_headers) { { some_bogus_headers: 'here' } }
   let(:token) { 'a_long_silly_token' }
+  let(:cookie_headers) do
+    { 'Set-Cookie': "folioAccessToken=#{token}; Expires=Fri, 22 Sep 2050 14:30:10 GMT; Path=/; Secure; HTTPOnly; SameSite=None" }
+  end
   let(:client) { FolioClient.instance }
   let(:id) { 'some_long_id_that_is_long' }
   let(:query) { '"active=="true"' }
@@ -15,8 +18,8 @@ RSpec.describe FolioClient::Organizations do
   before do
     FolioClient.configure(**args)
 
-    stub_request(:post, "#{url}/authn/login")
-      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+    stub_request(:post, "#{url}/authn/login-with-expiry")
+      .to_return(status: 200, headers: cookie_headers)
   end
 
   context 'when looking up a list of organizations' do

--- a/spec/folio_client/records_editor_spec.rb
+++ b/spec/folio_client/records_editor_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe FolioClient::RecordsEditor do
   let(:login_params) { { username: 'username', password: 'password' } }
   let(:okapi_headers) { { some_bogus_headers: 'here' } }
   let(:token) { 'aLongSTring.eNCodinga.JwTeeeee' }
+  let(:cookie_headers) do
+    { 'Set-Cookie': "folioAccessToken=#{token}; Expires=Fri, 22 Sep 2050 14:30:10 GMT; Path=/; Secure; HTTPOnly; SameSite=None" }
+  end
   let(:client) { FolioClient.instance }
   let(:hrid) { 'in00000000067' }
   let(:external_id) { '5108040a-65bc-40ed-bd50-265958301ce4' }
@@ -96,8 +99,8 @@ RSpec.describe FolioClient::RecordsEditor do
   before do
     FolioClient.configure(**args)
 
-    stub_request(:post, "#{url}/authn/login")
-      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+    stub_request(:post, "#{url}/authn/login-with-expiry")
+      .to_return(status: 200, headers: cookie_headers)
     allow(client).to receive(:fetch_instance_info).with(hrid: hrid).and_return({ '_version' => 1, 'id' => external_id })
     allow(client).to receive(:get).with('/records-editor/records',
                                         { externalId: external_id }).and_return(mock_response_json)

--- a/spec/folio_client/source_storage_spec.rb
+++ b/spec/folio_client/source_storage_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe FolioClient::SourceStorage do
   let(:login_params) { { username: 'username', password: 'password' } }
   let(:okapi_headers) { { some_bogus_headers: 'here' } }
   let(:token) { 'aLongSTring.eNCodinga.JwTeeeee' }
+  let(:cookie_headers) do
+    { 'Set-Cookie': "folioAccessToken=#{token}; Expires=Fri, 22 Sep 2050 14:30:10 GMT; Path=/; Secure; HTTPOnly; SameSite=None" }
+  end
   let(:client) { FolioClient.instance }
   let(:instance_hrid) { 'a666' }
   let(:search_instance_response) do
@@ -125,8 +128,8 @@ RSpec.describe FolioClient::SourceStorage do
     # simulates the initial obtainment of a valid token after FolioClient makes the very first post-initialization request.
     stub_request(:get, "#{url}/search/instances?query=hrid==in808")
       .to_return({ status: 401 }, { status: 200, body: search_instance_response.to_json })
-    stub_request(:post, "#{url}/authn/login")
-      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+    stub_request(:post, "#{url}/authn/login-with-expiry")
+      .to_return(status: 200, headers: cookie_headers)
 
     client.fetch_external_id(hrid: 'in808')
 

--- a/spec/folio_client/users_spec.rb
+++ b/spec/folio_client/users_spec.rb
@@ -10,6 +10,9 @@ RSpec.describe FolioClient::Users do
   let(:login_params) { { username: 'username', password: 'password' } }
   let(:okapi_headers) { { some_bogus_headers: 'here' } }
   let(:token) { 'a_long_silly_token' }
+  let(:cookie_headers) do
+    { 'Set-Cookie': "folioAccessToken=#{token}; Expires=Fri, 22 Sep 2050 14:30:10 GMT; Path=/; Secure; HTTPOnly; SameSite=None" }
+  end
   let(:client) { FolioClient.instance }
   let(:id) { 'some_long_id_that_is_long' }
   let(:query) { '"active=="true"' }
@@ -62,8 +65,8 @@ RSpec.describe FolioClient::Users do
   before do
     FolioClient.configure(**args)
 
-    stub_request(:post, "#{url}/authn/login")
-      .to_return(status: 200, body: "{\"okapiToken\" : \"#{token}\"}")
+    stub_request(:post, "#{url}/authn/login-with-expiry")
+      .to_return(status: 200, headers: cookie_headers)
   end
 
   context 'when looking up a list of users' do


### PR DESCRIPTION
## Why was this change made? 🤔
We should no longer use the `/auth/login` endpoint. Consumers are switched over to `legacy_auth: false` setting. This removes the old endpoint from FOLIO client.


## How was this change tested? 🤨
Tested with integration tests. 
