### PR TITLE
Add ostruct as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       faraday
       faraday-cookie_jar
       marc
+      ostruct
       zeitwerk
 
 GEM
@@ -79,6 +80,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.0-x86_64-linux-gnu)
       racc (~> 1.4)
+    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.10.1)
       ast (~> 2.4.1)

--- a/folio_client.gemspec
+++ b/folio_client.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday'
   spec.add_dependency 'faraday-cookie_jar'
   spec.add_dependency 'marc'
+  spec.add_dependency 'ostruct'
   spec.add_dependency 'zeitwerk'
 
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION


## Why was this change made? 🤔

It is no longer a default gem

## How was this change tested? 🤨
ci