### PR TITLE
Swap byebug for debug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in folio_client.gemspec
 gemspec
 
-gem 'byebug'
+gem 'debug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,13 +30,15 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     bigdecimal (4.0.1)
-    byebug (13.0.0)
-      reline (>= 0.6.0)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
+    date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.1)
     domain_name (0.6.20240107)
@@ -49,6 +51,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
+    erb (6.0.1)
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
@@ -64,6 +67,11 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
+    irb (1.17.0)
+      pp (>= 0.6.0)
+      prism (>= 1.3.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.18.1)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -83,11 +91,21 @@ GEM
     parser (3.3.10.1)
       ast (~> 2.4.1)
       racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
     prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
     public_suffix (7.0.2)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.3.1)
+    rdoc (7.2.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -144,6 +162,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
+    stringio (3.2.0)
+    tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -163,7 +183,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  byebug
+  debug
   folio_client!
   rake (~> 13.0)
   rspec (~> 3.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,7 @@ SimpleCov.start do
   end
 end
 
-require 'byebug'
+require 'debug'
 require 'folio_client'
 require 'webmock/rspec'
 


### PR DESCRIPTION
## Why was this change made? 🤔

ruby/debug is the official, modern debugger for Ruby included by default in Ruby 3.1+ and Rails 7+, offering better performance and advanced features. 

## How was this change tested? 🤨
ci

