### PR TITLE
Only update MARC record when the record has been changed.

### DIFF
--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -3,6 +3,7 @@
 require 'http/cookie' # Workaround for https://github.com/sparklemotion/http-cookie/issues/62
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/object/blank'
+require 'active_support/core_ext/object/deep_dup'
 require 'deprecation'
 require 'faraday'
 require 'faraday-cookie_jar'

--- a/lib/folio_client/records_editor.rb
+++ b/lib/folio_client/records_editor.rb
@@ -30,9 +30,11 @@ class FolioClient
       record_json['relatedRecordVersion'] = version
       record_json['_actionType'] = 'edit'
 
+      original_record_json = record_json.deep_dup
+
       yield record_json
 
-      client.put("/records-editor/records/#{parsed_record_id}", record_json)
+      client.put("/records-editor/records/#{parsed_record_id}", record_json) unless record_json == original_record_json
     end
 
     private

--- a/spec/folio_client/records_editor_spec.rb
+++ b/spec/folio_client/records_editor_spec.rb
@@ -127,4 +127,9 @@ RSpec.describe FolioClient::RecordsEditor do
     )
   end
   # rubocop:enable RSpec/ExampleLength
+
+  it 'does not PUT when the record JSON is unchanged' do
+    records_editor.edit_marc_json(hrid: hrid) { |editable_response_json| editable_response_json }
+    expect(client).not_to have_received(:put)
+  end
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/6198

## Why was this change made? 🤔
This avoids some of the cases in which SDR is trying to update an invalid MARC record.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

